### PR TITLE
Enhance the function trigger__parse.

### DIFF
--- a/sql/cat_tools.sql
+++ b/sql/cat_tools.sql
@@ -345,7 +345,7 @@ SELECT __cat_tools.create_function(
   , OUT defer text
   , OUT row_statement text
   , OUT when_clause text
-  , OUT function_arguments text
+  , OUT function_arguments text[]
   , OUT function_name text
   , OUT table_name text
 $$
@@ -408,7 +408,7 @@ BEGIN
   -- Get function arguments
   v_execute_clause := ' EXECUTE PROCEDURE ' || r_trigger.tgfoid::regproc || E'\\(';
   v_array := regexp_split_to_array( v_work, v_execute_clause );
-  function_arguments := rtrim( v_array[2], ')' ); -- Yank trailing )
+  function_arguments :=  array_remove(regexp_split_to_array(rtrim( v_array[2], ')' ), '\W+'), '');
 
   -- Get everything prior to EXECUTE PROCEDURE ...
   v_work := v_array[1];

--- a/sql/cat_tools.sql
+++ b/sql/cat_tools.sql
@@ -122,7 +122,7 @@ CREATE OR REPLACE VIEW _cat_tools.column AS
         -- domain
         WHEN 'd' THEN pg_catalog.format_type(typbasetype, typtypmod)
         -- enum
-        WHEN 'e' THEN 'text' 
+        WHEN 'e' THEN 'text'
         ELSE pg_catalog.format_type(typoid, atttypmod)
       END AS base_type
     , pk.conkey AS pk_columns
@@ -346,6 +346,8 @@ SELECT __cat_tools.create_function(
   , OUT row_statement text
   , OUT when_clause text
   , OUT function_arguments text
+  , OUT function_name text
+  , OUT table_name text
 $$
   , $$record LANGUAGE plpgsql$$
   , $body$
@@ -382,6 +384,10 @@ BEGIN
   v_on_clause := ' ON ' || r_trigger.tgrelid::regclass || ' ';
   v_array := regexp_split_to_array( v_work, v_on_clause );
   events := string_to_array( v_array[1], ' OR ' );
+
+ -- Get the name of the table that fires the trigger
+  table_name := r_trigger.tgrelid::regclass;
+
   -- Get everything after ON table_name
   v_work := v_array[2];
   RAISE DEBUG 'v_work "%"', v_work;
@@ -396,10 +402,14 @@ BEGIN
   END IF;
   RAISE DEBUG 'v_work "%"', v_work;
 
+  -- Get function name
+  function_name := r_trigger.tgfoid::regproc;
+
   -- Get function arguments
   v_execute_clause := ' EXECUTE PROCEDURE ' || r_trigger.tgfoid::regproc || E'\\(';
   v_array := regexp_split_to_array( v_work, v_execute_clause );
   function_arguments := rtrim( v_array[2], ')' ); -- Yank trailing )
+
   -- Get everything prior to EXECUTE PROCEDURE ...
   v_work := v_array[1];
   RAISE DEBUG 'v_work "%"', v_work;


### PR DESCRIPTION
Add the return variables:
function_name: the procedure name called by the trigger.
table_name: the table which the trigger is associated.
