### PR TITLE
Add CLAUDE.md: never delete branches without approval; always PR against main repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Claude Code Instructions for cat_tools
+
+## Git
+
+**Never delete a branch without explicit user approval.** This includes `git push origin --delete`, `git branch -d`, and `git branch -D`. Always ask first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,5 @@
 ## Git
 
 **Never delete a branch without explicit user approval.** This includes `git push origin --delete`, `git branch -d`, and `git branch -D`. Always ask first.
+
+**Always open PRs against the main repo** (`Postgres-Extensions/cat_tools`), not a fork.


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` with explicit directives:
  - Never delete a branch without user approval
  - Always open PRs against the main repo (`Postgres-Extensions/cat_tools`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)