### PR TITLE
Update pgxntool to 2.0.2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,7 @@
 .gitattributes export-ignore
+.claude/ export-ignore
+*.md export-ignore
+.DS_Store export-ignore
 *.asc export-ignore
 *.adoc export-ignore
 *.html export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .*.swp
+.claude/*.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,15 @@
 # Editor files
 .*.swp
 
+# Claude Code local settings
+.claude/*.local.json
+
 # Explicitly exclude META.json!
 !/META.json
 
 # Generated make files
 meta.mk
+control.mk
 
 # Compiler output
 *.o
@@ -13,8 +17,7 @@ meta.mk
 .deps/
 
 # built targets
-/sql/*--*
-!/sql/*--*--*.sql
+# Note: Version-specific files (sql/*--*.sql) are now tracked in git and should be committed
 
 # test targets
 /test/.build/
@@ -24,6 +27,17 @@ results/
 regression.diffs
 regression.out
 
+# Generated sql/ directory for test/build
+# Created by make test-build. See README.asc for details.
+test/build/sql/
+
+# Auto-generated schedule file for test/install
+# Created by make when test/install/*.sql files exist.
+test/install/schedule
+
 # Misc
 tmp/
 .DS_Store
+
+# pg_tle generated files
+/pg_tle/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,262 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Scope of This File
+
+The guidance in this CLAUDE.md applies to pgxntool's own source files and provides
+recommended best practices for projects using pgxntool. However, any agent working in
+an extension project should always defer to that project's own CLAUDE.md and
+instructions over anything stated here.
+
+## Git Commit Guidelines
+
+**IMPORTANT**: When creating commit messages, do not attribute commits to yourself (Claude). Commit messages should reflect the work being done without AI attribution in the message body. The standard Co-Authored-By trailer is acceptable.
+
+## Critical: What This Repo Actually Is
+
+**pgxntool is NOT a standalone project.** It is a meta-framework that exists ONLY to be embedded into PostgreSQL extension projects via `git subtree`. This repo cannot be built, tested, or run directly.
+
+**Think of it like this**: pgxntool is to PostgreSQL extensions what a Makefile template library is to C projects - it's infrastructure code that gets copied into other projects, not a project itself.
+
+## Critical: Directory Purity - NO Temporary Files
+
+**This directory contains ONLY files that get embedded into extension projects.** When extension developers run `git subtree add`, they pull the entire pgxntool directory into their project.
+
+**ABSOLUTE RULE**: NO temporary files, scratch work, or development tools may be added to this directory.
+
+**Examples of what NEVER belongs here:**
+- Temporary files (scratch notes, test output, debugging artifacts)
+- Development scripts or tools (these go in pgxntool-test/)
+- Planning documents (PLAN-*.md files go in pgxntool-test/)
+- Any file you wouldn't want in every extension project that uses pgxntool
+
+**CLAUDE.md exception**: CLAUDE.md exists here for AI assistant guidance, but is excluded from distributions via `.gitattributes export-ignore`. Same with `.claude/` directory.
+
+**Why this matters**: Any file you add here will be pulled into hundreds of extension projects via git subtree. Keep this directory lean and clean.
+
+## Development Workflow: Work from pgxntool-test
+
+**CRITICAL**: All development work on pgxntool should be done from the pgxntool-test repository, NOT from this repository.
+
+**For complete development workflow documentation, see:**
+https://github.com/Postgres-Extensions/pgxntool-test
+
+## Two-Repository Development Pattern
+
+This codebase uses a two-repository pattern:
+
+1. **pgxntool/** (this repo) - The framework code that gets embedded into extension projects
+2. **pgxntool-test** - The test harness that validates pgxntool functionality
+
+**For development and testing workflow, see:**
+https://github.com/Postgres-Extensions/pgxntool-test
+
+## How Extension Developers Use pgxntool
+
+Extension projects include pgxntool via git subtree:
+
+```bash
+git subtree add -P pgxntool --squash git@github.com:decibel/pgxntool.git release
+pgxntool/setup.sh
+```
+
+After setup, their Makefile typically contains just:
+```makefile
+include pgxntool/base.mk
+```
+
+## Architecture: Two-Phase Build System
+
+### Phase 1: Meta Generation (`build_meta.sh`)
+- Processes `META.in.json` (template with placeholders/empty values)
+- Strips out X_comment fields and empty values
+- Produces clean `META.json`
+
+### Phase 2: Variable Extraction (`meta.mk.sh`)
+- Parses `META.json` using `JSON.sh` (a bash-based JSON parser)
+- Generates `meta.mk` with Make variables:
+  - `PGXN` - distribution name
+  - `PGXNVERSION` - version number
+  - `EXTENSIONS` - list of extensions provided
+  - `EXTENSION_*_VERSION` - per-extension versions
+  - `EXTENSION_VERSION_FILES` - auto-generated versioned SQL files
+- `base.mk` includes `meta.mk` via `-include`
+
+### The Magic of base.mk
+
+`base.mk` provides a complete PGXS-based build system:
+- Auto-detects extension SQL files in `sql/`
+- Auto-detects C modules in `src/*.c`
+- Auto-detects tests in `test/sql/*.sql`
+- Auto-generates versioned extension files (`extension--version.sql`)
+- Handles Asciidoc → HTML conversion
+- Integrates with PGXN distribution format
+- Manages git tagging and release packaging
+
+## File Structure for Consumer Projects
+
+Projects using pgxntool follow this layout:
+```
+project/
+├── Makefile                    # include pgxntool/base.mk
+├── META.in.json               # Template metadata (customize for your extension)
+├── META.json                  # Auto-generated from META.in.json
+├── extension.control          # Standard PostgreSQL control file
+├── pgxntool/                  # This repo, embedded via git subtree
+├── sql/
+│   └── extension.sql          # Base extension SQL
+├── src/                       # Optional C code (*.c files)
+├── test/
+│   ├── deps.sql              # Load extension and test dependencies
+│   ├── sql/*.sql             # Test SQL files
+│   └── expected/*.out        # Expected test outputs
+└── doc/                       # Optional docs (*.adoc, *.asciidoc)
+```
+
+## Commands for Extension Developers (End Users)
+
+These are the commands extension developers use (documented for context):
+
+```bash
+make                    # Build extension (generates versioned SQL, docs)
+make test              # Full test: testdeps → install → installcheck → show diffs
+make results           # Run tests and update expected output files
+make html              # Generate HTML from Asciidoc sources
+make tag               # Create git branch for current META.json version
+make dist              # Create PGXN .zip (auto-tags, places in ../)
+make pgtle             # Generate pg_tle registration SQL (see pg_tle Support below)
+make check-pgtle       # Check pg_tle installation and report version
+make install-pgtle    # Install pg_tle registration SQL files into database
+make pgxntool-sync     # Update to latest pgxntool via git subtree pull
+```
+
+## Testing with pgxntool
+
+### Critical Testing Rules
+
+**NEVER use `make installcheck` directly**. Always use `make test` instead. The `make test` target ensures:
+- Clean builds before testing
+- Proper test isolation
+- Correct test dependency installation
+- Proper cleanup and result comparison
+
+**Database Connection Requirement**: PostgreSQL must be running before executing `make test`. If you get connection errors (e.g., "could not connect to server"), stop and ask the user to start PostgreSQL.
+
+**Claude Code MUST NEVER run `make results`**. This target updates test expected output files and requires manual human verification of test changes before execution.
+
+**Claude Code MUST NEVER modify files in `test/expected/`**. These are expected test outputs that define correct behavior and must only be updated through the `make results` workflow.
+
+The workflow is:
+1. Human runs `make test` and examines diffs
+2. Human manually verifies changes are correct
+3. Human manually runs `make results` to update expected files
+
+### Test Output Mechanics
+
+pgxntool uses PostgreSQL's pg_regress test framework:
+- **Actual test output**: Written to `test/results/` directory
+- **Expected output**: Stored in `test/expected/` directory
+- **Test comparison**: pg_regress compares actual vs expected and generates diffs; `make test` displays them
+- **Updating expectations**: `make results` copies `test/results/` → `test/expected/`
+
+When tests fail, examine the diff output carefully. The actual test output in `test/results/` shows what your code produced, while `test/expected/` shows what was expected.
+
+## Key Implementation Details
+
+### PostgreSQL Version Handling
+- `MAJORVER` = version × 10 (e.g., 9.6 → 96, 13 → 130)
+- Tests use `--load-language=plpgsql` for versions < 13
+- Version detection via `pg_config --version`
+
+### Test System (pg_regress based)
+- Tests in `test/sql/*.sql`, outputs compared to `test/expected/*.out`
+- Setup via `test/pgxntool/setup.sql` (loads pgTap and deps.sql)
+- `.IGNORE: installcheck` allows `make test` to handle errors (show diffs, then exit with error status)
+- `make results` updates expected outputs after test runs
+
+### Document Generation
+- Auto-detects `asciidoctor` or `asciidoc`
+- Generates HTML from `*.adoc` and `*.asciidoc` in `$(DOC_DIRS)`
+- HTML required for `make dist`, optional for `make install`
+- Template-based rules via `ASCIIDOC_template`
+
+### Distribution Packaging
+- `make dist` creates `../PGXN-VERSION.zip`
+- Always creates git branch tag matching version
+- Uses `git archive` to package
+- Validates repo is clean before tagging
+
+### Subtree Sync Support
+- `make pgxntool-sync` pulls latest release
+- Multiple sync targets: release, stable, local variants
+- Uses `git subtree pull --squash`
+- Requires clean repo (no uncommitted changes)
+
+### pg_tle Support
+
+pgxntool can generate pg_tle (Trusted Language Extensions) registration SQL for deploying extensions in AWS RDS/Aurora without filesystem access.
+
+**Usage:** `make pgtle` or `make pgtle PGTLE_VERSION=1.5.0+`
+
+**Output:** `pg_tle/{version_range}/{extension}.sql`
+
+**For version range details and API compatibility boundaries, see:** `pgtle_versions.md`
+
+**Installation targets:**
+
+- `make check-pgtle` - Checks if pg_tle is installed and reports the version. Reports version from `pg_extension` if extension has been created, or newest available version from `pg_available_extension_versions` if available but not created. Errors if pg_tle not available in cluster. Assumes `PG*` environment variables are configured.
+
+- `make install-pgtle` - Auto-detects pg_tle version and installs appropriate registration SQL files. Updates or creates pg_tle extension as needed. Determines which version range files to install based on detected version. Runs all generated SQL files via `psql` to register extensions with pg_tle. Assumes `PG*` environment variables are configured.
+
+**Version notation:**
+- `X.Y.Z+` means >= X.Y.Z
+- `X.Y.Z-A.B.C` means >= X.Y.Z and < A.B.C (note boundary)
+
+**Key implementation details:**
+- Script: `pgxntool/pgtle-wrap.sh` (bash)
+- Parses `.control` files for metadata (NOT META.json)
+- Fixed delimiter: `$_pgtle_wrap_delimiter_$` (validated not in source)
+- Each output file contains ALL versions and ALL upgrade paths
+- Multi-extension support (multiple .control files)
+- Output directory `pg_tle/` excluded from git
+- Depends on `make all` to ensure versioned SQL files exist first
+- Only processes versioned files (`sql/{ext}--{version}.sql`), not base files
+
+**SQL file handling:**
+- **Version files** (`sql/{ext}--{version}.sql`): Generated automatically by `make all` from base `sql/{ext}.sql` file
+- **Upgrade scripts** (`sql/{ext}--{v1}--{v2}.sql`): Created manually by users when adding new extension versions
+- The script ensures the default_version file exists if the base file exists (creates it from base file if missing)
+- All version files and upgrade scripts are discovered and included in the generated pg_tle registration SQL
+
+**Dependencies:**
+Generated files depend on:
+- Control file (metadata source)
+- All SQL files (sql/{ext}--*.sql) - must run `make all` first
+- Generator script itself
+
+**Limitations:**
+- No C code support (pg_tle requires trusted languages only)
+- PostgreSQL 14.5+ required (pg_tle not available on earlier versions)
+
+## Critical Gotchas
+
+1. **Empty Variables**: If `DOCS` or `MODULES` is empty, base.mk sets to empty to prevent PGXS errors
+2. **testdeps Pattern**: Never add recipes to `testdeps` - create separate target and make it a prerequisite
+3. **META.json is Generated**: Always edit `META.in.json`, never `META.json` directly
+4. **Control File Versions**: No automatic validation that `.control` matches `META.json` version
+5. **PGXNTOOL_NO_PGXS_INCLUDE**: Setting this skips PGXS inclusion (for special scenarios)
+6. **Distribution Placement**: `.zip` files go in parent directory (`../`) to avoid repo clutter
+
+## Scripts
+
+- **setup.sh** - Initializes pgxntool in a new extension project (copies templates, creates directories)
+- **build_meta.sh** - Strips empty fields from META.in.json to create META.json
+- **meta.mk.sh** - Parses META.json via JSON.sh and generates meta.mk with Make variables
+- **JSON.sh** - Third-party bash JSON parser (MIT licensed)
+- **safesed** - Utility for safe sed operations
+
+## Related Repositories
+
+- **pgxntool-test** - Test harness for validating pgxntool functionality: https://github.com/Postgres-Extensions/pgxntool-test
+- Never produce any kind of metrics or estimates unless you have data to back them up. If you do have data you MUST reference it.

--- a/HISTORY.asc
+++ b/HISTORY.asc
@@ -1,10 +1,95 @@
-STABLE
-------
+2.0.2
+-----
+== Fix parse_control_file corrupting values with trailing comments
+Control file values like `default_version = '1.0.0' # comment` were parsed
+incorrectly — the trailing quote was left in the value due to comment removal
+happening after quote stripping. Fixed by removing comments first.
+
+2.0.1
+-----
+== Improve bash compatibility (specifically for Mac OS)
+Mac OS uses the (very old) bash 3.2 as the default shell; fix a few compatibility bugs.
+
+2.0.0
+-----
+== Remove .source file support
+PostgreSQL removed `.source` file processing from `pg_regress` in PG15.
+The `input/*.source` → `sql/*.sql` and `output/*.source` →
+`expected/*.out` conversion mechanism no longer functions. All related
+variables (`TEST__SOURCE__*`), the `make_results.sh` helper script, and
+the special-case logic in `make results` have been removed. Extensions
+that used `.source` files should convert them to regular `test/sql/*.sql`
+and `test/expected/*.out` files using relative paths.
+
+== Add test-build for pre-test validation
+When CREATE EXTENSION fails due to a SQL syntax error, PostgreSQL reports only a cryptic error with limited context. test-build runs your extension SQL directly through pg_regress first, so syntax errors show the exact file, line, and position — cutting debugging time significantly. Place SQL files in `test/build/` to enable; auto-detects based on file presence.
+
+== Add test/install for one-time test setup
+Extensions that install dependencies or run expensive setup in every test file pay that cost once per test. test/install runs setup SQL once before the entire test suite, and all regular tests share the resulting database state. This can dramatically speed up test suites that install extensions or load fixtures. Place SQL files in `test/install/` to enable; auto-detects based on file presence.
+
+== Add verify-results safeguard for make results
+`make results` now refuses to run when tests are failing (detected via `regression.diffs`). Prevents accidentally blessing incorrect output as the new expected results. Enabled by default; disable with `PGXNTOOL_ENABLE_VERIFY_RESULTS=no`.
+
+== Fix bash 3.2 compatibility and shebang portability
+`${#ARRAY[@]:-0}` is a syntax error in bash 3.2; replaced with `${#ARRAY[@]}`.
+Shell scripts now use `#!/usr/bin/env bash`.
+
+1.1.2
+-----
+== Fix double --dbname bug that defeated unique test database names
+The unique database naming introduced in 1.1.0 was ineffective because
+base.mk added --dbname=$(REGRESS_DBNAME) to REGRESS_OPTS while PGXS
+also appends --dbname=$(CONTRIB_TESTDB). The second --dbname caused
+pg_regress to create a contrib_regression database that collided across
+projects. Fixed by overriding CONTRIB_TESTDB after include $(PGXS) instead.
+
+1.1.1
+-----
+== Fix pg_tle exception handler and empty upgrade files
+The exception handler for `uninstall_extension()` now correctly catches
+`no_data_found` (P0002) instead of `undefined_object` (42704). Empty upgrade
+files are now treated as valid no-op upgrades for version bumps. Added
+`ON_ERROR_STOP=1` to `run_pgtle_sql()` so psql errors propagate correctly.
+
+1.1.0
+-----
+== Use unique database names for tests
+Tests now use a unique database name based on the project name and a hash of the
+current directory. This prevents test conflicts when running tests for multiple
+projects in parallel.
+
+== Add 3-way merge support for setup files after pgxntool-sync
+New `update-setup-files.sh` script handles merging changes to files initially
+copied by `setup.sh` (`.gitignore`, `test/deps.sql`). After running `make
+pgxntool-sync`, the script performs a 3-way merge if both you and pgxntool have
+modified the same file, using git's native conflict markers for resolution.
+
+1.0.0
+-----
+== Fix broken multi-extension support
+Prior to this fix, distributions with multiple extensions or extensions with
+versions different from the PGXN distribution version were completely broken.
+Extension versions are now correctly read from each `.control` file's
+`default_version` instead of using META.json's distribution version.
+
+== Add pg_tle support
+New `make pgtle` target generates pg_tle registration SQL for extensions.
+Supports pg_tle version ranges (1.0.0-1.4.0, 1.4.0-1.5.0, 1.5.0+) with
+appropriate API calls for each range. See README for usage.
+
+== Use git tags for distribution versioning
+The `tag` and `rmtag` targets now create/delete git tags instead of branches.
+
+== Support 13+
+The `--load-language` option was removed from `pg_regress` in 13.
+
 == Reduce verbosity from test setup
 As part of this change, you will want to review the changes to test/deps.sql.
 
 === Support asciidoc documentation targets
-By default, if asciidoctor or asciidoc exists on the system, any files in doc/ that end in .adoc or .asciidoc will be processed to html.
+By default, if asciidoctor or asciidoc exists on the system, any files in doc/
+that end in .adoc or .asciidoc will be processed to html.
+
 See the README for full details.
 
 === Support 9.2
@@ -32,7 +117,7 @@ VERSION is defined by PGXS itself, so trying to use it causes problems.
 Old code didn't deal with the lack of a . that can appear in a 10+ version.
 
 0.1.10
-------
+-----
 ### Remove invalid `git subtree pull` options
 
 0.1.9

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015, Jim Nasby, Blue Treble Solutions
+Copyright (c) 2015-2026, Jim Nasby, Blue Treble Solutions
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.asc
+++ b/README.asc
@@ -23,6 +23,10 @@ pgxntool/setup.sh
 
 TODO: Create a nice script that will init a new project for you.
 
+== Development
+
+If you want to contribute to pgxntool development, work from the https://github.com/decibel/pgxntool-test[pgxntool-test] repository, not from this repository. That repository contains the test infrastructure and development tools needed to validate changes to pgxntool. This repository contains only the framework files that get embedded into extension projects via `git subtree`.
+
 == Usage
 Typically, you can just create a simple Makefile that does nothing but include base.mk:
 
@@ -40,6 +44,122 @@ This will build any .html files that can be created. See <<_Document_Handling>>.
 
 === test
 Runs unit tests via the PGXS `installcheck` target. Unlike a simple `make installcheck` though, the `test` rule has the following prerequisites: clean testdeps install installcheck. All of those are PGXS rules, except for `testdeps`.
+
+NOTE: While you can still run `make installcheck` or any other valid PGXS make target directly, it's recommended to use `make test` when using pgxntool. The `test` target ensures clean builds, proper test isolation, and correct dependency installation.
+
+=== test-build
+Validates that extension SQL files are syntactically correct before running the full test suite. This feature runs SQL files from `test/build/` through `pg_regress`, providing better error messages than `CREATE EXTENSION` failures when there are syntax errors in your extension code.
+
+**How it works:**
+
+1. Place SQL files in `test/build/*.sql`
+2. Place expected output in `test/build/expected/*.out`
+3. These files run through `pg_regress` before `make test` runs the main test suite
+4. If any build test fails, the test run stops immediately with clear error messages
+
+**Directory structure:**
+
+----
+test/build/
+├── *.sql              # SQL test files (checked in)
+├── expected/          # Expected output files (checked in)
+│   └── *.out
+└── sql/               # GENERATED - do not edit or check in
+    └── *.sql          # Synced from *.sql above
+----
+
+The `sql/` subdirectory is generated automatically by `make test-build`. It is listed in `.gitignore` and removed by `make clean`. Do not place files directly in `test/build/sql/`.
+
+**Configuration:**
+
+The feature auto-detects based on whether `test/build/*.sql` files exist:
+
+- Files present → feature enabled automatically
+- No files → feature disabled (no impact on existing projects)
+
+You can override auto-detection by setting `PGXNTOOL_ENABLE_TEST_BUILD`:
+----
+# In your Makefile
+PGXNTOOL_ENABLE_TEST_BUILD = yes  # or no
+----
+
+**Example: Validate extension SQL compiles**
+
+Create `test/build/build.sql` to run your extension's SQL directly:
+
+----
+\set ECHO none
+-- Sets ON_ERROR_STOP, VERBOSITY verbose, and ON_ERROR_ROLLBACK
+\i test/pgxntool/psql.sql
+-- Suppress column headers and row counts for cleaner expected output
+\t
+
+BEGIN;
+SET client_min_messages = WARNING;
+
+-- Install dependencies your extension requires
+CREATE EXTENSION IF NOT EXISTS pgtap CASCADE;
+
+-- Clean slate
+DROP EXTENSION IF EXISTS myext;
+DROP SCHEMA IF EXISTS myext;
+CREATE SCHEMA myext;
+
+-- Run the actual extension SQL (not CREATE EXTENSION)
+-- psql.sql above ensures errors abort immediately with clear messages
+\i sql/myext.sql
+
+-- If we get here, the build succeeded; ON_ERROR_STOP would have aborted on any error above
+\echo # BUILD TEST SUCCEEDED
+ROLLBACK;
+----
+
+This approach catches SQL syntax errors *before* running `CREATE EXTENSION`, giving clearer error messages with line numbers. The `ROLLBACK` ensures nothing persists—this is purely validation.
+
+**Why use `\i` instead of `CREATE EXTENSION`?**
+
+When `CREATE EXTENSION` fails, PostgreSQL shows only "syntax error" with limited context. Running the SQL directly via `\i` shows the exact line and position of errors, making debugging much faster.
+
+=== test/install
+Runs setup files before the main test suite within the same `pg_regress` invocation. This allows expensive one-time operations (like extension installation) to set up state that persists into the regular test files.
+
+**How it works:**
+
+1. Place SQL files in `test/install/*.sql`
+2. Place expected output alongside as `test/install/*.out`
+3. A schedule file is auto-generated that lists install files with `../install/` relative paths
+4. `pg_regress` processes the install schedule first, then runs regular test files — all in one invocation, so database state persists
+
+**Directory structure:**
+
+----
+test/install/
+├── *.sql              # SQL setup files (checked in)
+├── *.out              # Expected output (checked in, alongside .sql)
+├── .gitignore         # Ignores pg_regress artifacts (*.out.diff)
+└── schedule           # GENERATED - auto-created by make
+----
+
+The `schedule` file is generated automatically and listed in `.gitignore`. Do not edit it.
+
+**Configuration:**
+
+The feature auto-detects based on whether `test/install/*.sql` files exist:
+
+- Files present → feature enabled automatically
+- No files → feature disabled (no impact on existing projects)
+
+You can override auto-detection by setting `PGXNTOOL_ENABLE_TEST_INSTALL`:
+----
+# In your Makefile
+PGXNTOOL_ENABLE_TEST_INSTALL = yes  # or no
+----
+
+**Why this is useful:**
+
+Without `test/install`, each test file typically needs to run `CREATE EXTENSION` in its setup, which adds overhead and doesn't allow validating the installation step separately. With `test/install`, setup runs once before all tests, and any state it creates (tables, extensions, etc.) is available to every subsequent test file.
+
+**Key detail:** Install files and regular tests run in a single `pg_regress` invocation. This means the database is NOT dropped between install and test phases — state created by install files persists into the main test suite.
 
 === testdeps
 This rule allows you to ensure certain actions have taken place before running tests. By default it has a single prerequisite, `pgtap`, which will attempt to install http://pgtap.org[pgtap] from PGXN. This depneds on having the pgxn client installed.
@@ -60,9 +180,35 @@ If you want to over-ride the default dependency on `pgtap` you should be able to
 WARNING: It will probably cause problems if you try to create a `testdeps` rule that has a recipe. Instead of doing that, put the recipe in a separate rule and make that rule a prerequisite of `testdeps` as show in the example.
 
 === results
-Because `make test` ultimately runs `installcheck`, it's using the Postgres test suite. Unfortunately, that suite is based on running `diff` between a raw output file and expected results. I *STRONGLY* recommend you use http://pgtap.org[pgTap] instead! The extra effort of learning pgTap will quickly pay for itself. https://github.com/decibel/trunklet-format/blob/master/test/sql/base.sql[This example] might help get you started.
+Because `make test` ultimately runs `installcheck`, it's using the Postgres test suite. Unfortunately, that suite is based on running `diff` between a raw output file and expected results. I *STRONGLY* recommend you use http://pgtap.org[pgTap] instead! With pgTap, it's MUCH easier to determine whether a test is passing or not - tests explicitly pass or fail rather than requiring you to examine diff output. The extra effort of learning pgTap will quickly pay for itself. https://github.com/decibel/trunklet-format/blob/master/test/sql/base.sql[This example] might help get you started.
 
 No matter what method you use, once you know that all your tests are passing correctly, you need to create or update the test output expected files. `make results` does that for you.
+
+IMPORTANT: *`make results` requires manual verification first*. The correct workflow is:
+
+1. Run `make test` and examine the diff output
+2. Manually verify that the differences are correct and expected
+3. Only then run `make results` to update the expected output files in `test/expected/`
+
+Never run `make results` without first verifying the test changes are correct. The `results` target copies files from `test/results/` to `test/expected/`, so running it blindly will make incorrect output become the new expected behavior.
+
+==== verify-results safeguard
+By default, `make results` will refuse to run if `test/results/regression.diffs` exists (indicating failing tests). This prevents accidentally updating expected files with incorrect output.
+
+If tests are failing, you'll see:
+----
+ERROR: Tests are failing. Cannot run 'make results'.
+Fix test failures first, then run 'make results'.
+----
+
+To disable this safeguard (not recommended):
+----
+# In your Makefile
+PGXNTOOL_ENABLE_VERIFY_RESULTS = no
+
+# Or on the command line
+make PGXNTOOL_ENABLE_VERIFY_RESULTS=no results
+----
 
 === tag
 `make tag` will create a git branch for the current version of your extension, as determined by the META.json file. The reason to do this is so you can always refer to the exact code that went into a released version.
@@ -82,6 +228,119 @@ This rule will pull down the latest released version of PGXNtool via `git subtre
 NOTE: Your repository must be clean (no modified files) in order to run this. Running this command will produce a git commit of the merge.
 
 TIP: There is also a `pgxntool-sync-%` rule if you need to do more advanced things.
+
+=== distclean
+`make distclean` removes generated configuration files (`META.json`, `meta.mk`, `control.mk`) that survive a normal `make clean`.
+
+NOTE: PGXS doesn't provide any special support for `distclean` — its built-in `distclean` target simply depends on `clean`. PGXNtool uses its own `PGXNTOOL_distclean` variable to track files that should only be removed by `distclean`, not `clean`.
+
+If your extension generates additional files that should be removed by `distclean` but not `clean`, you can add them:
+----
+PGXNTOOL_distclean += my_generated_config.mk
+----
+
+=== pgtle
+Generates pg_tle (Trusted Language Extensions) registration SQL files for deploying extensions in managed environments like AWS RDS/Aurora. See <<_pg_tle_Support>> for complete documentation.
+
+`make pgtle` generates SQL files in `pg_tle/` subdirectories organized by pg_tle version ranges. For version range details, see `pgtle_versions.md`.
+
+=== check-pgtle
+Checks if pg_tle is installed and reports the version. This target:
+- Reports the version from `pg_extension` if `CREATE EXTENSION pg_tle` has been run in the database
+- Errors if pg_tle is not available in the cluster
+
+This target assumes `PG*` environment variables are configured for `psql` connectivity.
+
+----
+make check-pgtle
+----
+
+=== run-pgtle
+Registers all extensions with pg_tle by executing the generated pg_tle registration SQL files in a PostgreSQL database. This target:
+- Requires pg_tle extension to be installed (checked via `check-pgtle`)
+- Uses `pgtle.sh` to determine which version range directory to use based on the installed pg_tle version
+- Runs all generated SQL files via `psql` to register your extensions with pg_tle
+
+This target assumes that running `psql` without any arguments will connect to the desired database. You can control this by setting the various PG* environment variables (and possibly using the `.pgpassword` file). See the PostgreSQL documentation for more details.
+
+NOTE: The `pgtle` target is a dependency, so `make run-pgtle` will automatically generate the SQL files if needed.
+
+----
+make run-pgtle
+----
+
+After running `make run-pgtle`, you can create your extension in the database:
+----
+CREATE EXTENSION "your-extension-name";
+----
+
+== Version-Specific SQL Files
+
+PGXNtool automatically generates version-specific SQL files from your base SQL file. These files follow the pattern `sql/{extension}--{version}.sql` and are used by PostgreSQL's extension system to install specific versions of your extension.
+
+=== How Version Files Are Generated
+
+When you run `make` (or `make all`), PGXNtool:
+
+1. Reads your `META.json` file to determine the extension version from `provides.{extension}.version`
+2. Generates a Makefile rule that copies your base SQL file (`sql/{extension}.sql`) to the version-specific file (`sql/{extension}--{version}.sql`)
+3. Executes this rule, creating the version-specific file with a header comment indicating it's auto-generated
+
+For example, if your `META.json` contains:
+----
+"provides": {
+  "myext": {
+    "version": "1.2.3",
+    ...
+  }
+}
+----
+
+Running `make` will create `sql/myext--1.2.3.sql` by copying `sql/myext.sql`.
+
+=== What Controls the Version Number
+
+The version number comes from `META.json` → `provides.{extension}.version`, *not* from your `.control` file's `default_version` field. The `.control` file's `default_version` is used by PostgreSQL to determine which version to install by default, but the actual version-specific file that gets generated is determined by what's in `META.json`.
+
+To change the version of your extension:
+1. Update `provides.{extension}.version` in `META.json`
+2. Run `make` to regenerate the version-specific file
+3. Update `default_version` in your `.control` file to match (if needed)
+
+=== Committing Version Files
+
+Version-specific SQL files are now treated as permanent files that should be committed to your repository. This makes it much easier to test updates to extensions, as you can see exactly what SQL was included in each version.
+
+IMPORTANT: These files are auto-generated and include a header comment warning not to edit them. Any manual changes will be overwritten the next time you run `make`. To modify the extension, edit the base SQL file (`sql/{extension}.sql`) instead.
+
+=== Alternative: Ignoring Version Files
+
+If you prefer not to commit version-specific SQL files, you must add them to your `.gitignore` to prevent `make dist` from failing due to untracked files. Add the following to your `.gitignore`:
+
+----
+# Auto-generated version-specific SQL files (if not committing them)
+sql/*--*.sql
+!sql/*--*--*.sql
+----
+
+The second line (`!sql/*--*--*.sql`) ensures that upgrade scripts (which contain two version numbers and should be manually written) are still tracked.
+
+WARNING: If you ignore version files instead of committing them, they will NOT be included in your PGXN distribution (`make dist` uses `git archive`, which only includes tracked files). This means users installing your extension from PGXN will need `make` and PGXS available to build the extension - they cannot simply copy the SQL files into their PostgreSQL installation. For maximum compatibility, we recommend committing version files.
+
+=== Distribution Inclusion
+
+Version-specific files are included in distributions created by `make dist` only if they are committed to git. Since `make dist` uses `git archive`, only tracked files are included in the distribution archive.
+
+=== Multiple Versions
+
+If you need to support multiple versions of your extension:
+
+1. Create additional version-specific files manually (e.g., `sql/myext--1.0.0.sql`, `sql/myext--1.1.0.sql`)
+2. Create upgrade scripts for version transitions (e.g., `sql/myext--1.0.0--1.1.0.sql`)
+3. Update `META.json` to reflect the current version you're working on
+4. Commit all version files and upgrade scripts to your repository
+
+The version file for the current version (specified in `META.json`) will be automatically regenerated when you run `make`, but other version files you create manually will be preserved.
 
 == Document Handling
 PGXNtool supports generation and installation of document files. There are several variables and rules that control this behavior.
@@ -106,7 +365,7 @@ Location of `asciidoc` or equivalent executable.
 If not set PGXNtool will search for first `asciidoctor`, then `asciidoc`.
 ASCIIDOC_EXTS::
 File extensions to consider as Asciidoc.
-Defined as `+= adoc asciidoc`.
+Defined as `+= adoc asciidoc asc`.
 ASCIIDOC_FILES::
 Asciidoc input files.
 PGXNtool searches each `$(DOC_DIRS)` directory, looking for files with any `$(ASCIIDOC_EXTS)` extension.
@@ -158,7 +417,111 @@ Because of this, `base.mk` will forcibly define it to be NULL if it's empty.
 
 PGXNtool appends *all* files found in all `$(DOC_DIRS)` to `DOCS`.
 
+== pg_tle Support
+[[_pg_tle_Support]]
+pgxntool can generate link:https://github.com/aws/pg_tle[pg_tle (Trusted Language Extensions)] registration SQL for deploying PostgreSQL extensions in managed environments like AWS RDS and Aurora where filesystem access is not available.
+
+For make targets, see: <<_pgtle>>, <<_check_pgtle>>, <<_run_pgtle>>.
+
+=== What is pg_tle?
+
+pg_tle is an AWS open-source framework that enables developers to create and deploy PostgreSQL extensions without filesystem access. Traditional PostgreSQL extensions require `.control` and `.sql` files on the filesystem, which isn't possible in managed services like RDS and Aurora.
+
+pg_tle solves this by:
+- Storing extension metadata and SQL in database tables
+- Using the `pgtle_admin` role for administrative operations
+- Enabling `CREATE EXTENSION` to work in managed environments
+
+=== Quick Start
+
+Generate pg_tle registration SQL for your extension:
+
+----
+make pgtle
+----
+
+This creates files in `pg_tle/` subdirectories organized by pg_tle version ranges. See `pgtle_versions.md` for complete version range details and API compatibility boundaries.
+
+=== Version Groupings
+
+pgxntool creates different sets of files for different pg_tle versions to handle backward-incompatible API changes. Each version boundary represents a change to pg_tle's API functions that we use.
+
+For details on version boundaries and API changes, see `pgtle_versions.md`.
+
+=== Installation Example
+
+IMPORTANT: This is only a basic example. Always refer to the link:https://github.com/aws/pg_tle[main pg_tle documentation] for complete installation instructions and best practices.
+
+Basic installation steps:
+
+. Ensure pg_tle is installed and grant the `pgtle_admin` role to your user
+. Generate and run the pg_tle registration SQL files:
++
+----
+make run-pgtle
+----
++
+This automatically detects your pg_tle version and runs the appropriate SQL files. See `pgtle_versions.md` for version range details.
+. Create your extension: `CREATE EXTENSION myextension;`
+
+=== Advanced Usage
+
+==== Multi-Extension Projects
+
+If your project has multiple extensions (multiple `.control` files), `make pgtle` generates files for all of them:
+
+----
+myproject/
+├── ext1.control
+├── ext2.control
+└── pg_tle/
+    ├── 1.0.0-1.5.0/
+    │   ├── ext1.sql
+    │   └── ext2.sql
+    └── 1.5.0+/
+        ├── ext1.sql
+        └── ext2.sql
+----
+
+=== How It Works
+`make pgtle` does the following:
+
+. Parses control file(s): Extracts `comment`, `default_version`, `requires`, and `schema` fields
+. Discovers SQL files: Finds all versioned files (`sql/{ext}--{version}.sql`) and upgrade scripts (`sql/{ext}--{ver1}--{ver2}.sql`)
+. Wraps SQL content: Uses a fixed dollar-quote delimiter (`$_pgtle_wrap_delimiter_$`) to wrap SQL for pg_tle functions
+. Generates registration SQL: Creates `pgtle.install_extension()` calls for each version, `pgtle.install_update_path()` for upgrades, and `pgtle.set_default_version()` for the default
+. Version-specific output: Generates separate files for different pg_tle capability levels
+
+Each generated SQL file is wrapped in a transaction (`BEGIN;` ... `COMMIT;`) to ensure atomic installation.
+
+=== Troubleshooting
+
+==== "No versioned SQL files found"
+
+*Problem*: The script can't find `sql/{ext}--{version}.sql` files.
+
+*Solution*: Run `make` first to generate versioned files from your base `sql/{ext}.sql` file.
+
+==== "Control file not found"
+
+*Problem*: The script can't find `{ext}.control` in the current directory.
+
+*Solution*: Run `make pgtle` from your extension's root directory (where the `.control` file is).
+
+==== "SQL file contains reserved pg_tle delimiter"
+
+*Problem*: Your SQL files contain the string `$_pgtle_wrap_delimiter_$` (extremely unlikely).
+
+*Solution*: Don't use that dollar-quote delimiter in your code.
+
+==== Extension uses C code
+
+*Problem*: Your control file has `module_pathname`, indicating C code.
+
+*Solution*: pg_tle only supports trusted languages. You cannot use C extensions with pg_tle. The script will warn you but still generate files (which won't work).
+
+NOTE: there are several untrusted languages (such as plpython), and the only tests for C.
 == Copyright
-Copyright (c) 2015 Jim Nasby <Jim.Nasby@BlueTreble.com>
+Copyright (c) 2026 Jim Nasby <Jim.Nasby@gmail.com>
 
 PGXNtool is released under a https://github.com/decibel/pgxntool/blob/master/LICENCE[BSD license]. Note that it includes https://github.com/dominictarr/JSON.sh[JSON.sh], which is released under a https://github.com/decibel/pgxntool/blob/master/JSON.sh.LICENCE[MIT license].

--- a/README.html
+++ b/README.html
@@ -2,31 +2,26 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 1.5.4">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <meta name="author" content="Easier PGXN development">
 <title>PGXNtool</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
-/* Remove comment around @import statement below when using as a custom stylesheet */
-/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
-article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
-audio,canvas,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-[hidden],template{display:none}
-script{display:none!important}
-html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
-body{margin:0}
-a{background:transparent}
+/*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment the following line when using as a custom stylesheet */
+/* @import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700"; */
+html{font-family:sans-serif;-webkit-text-size-adjust:100%}
+a{background:none}
 a:focus{outline:thin dotted}
 a:active,a:hover{outline:0}
 h1{font-size:2em;margin:.67em 0}
-abbr[title]{border-bottom:1px dotted}
 b,strong{font-weight:bold}
+abbr{font-size:.9em}
+abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
 dfn{font-style:italic}
-hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
+hr{height:0}
 mark{background:#ff0;color:#000}
 code,kbd,pre,samp{font-family:monospace;font-size:1em}
 pre{white-space:pre-wrap}
@@ -38,22 +33,22 @@ sub{bottom:-.25em}
 img{border:0}
 svg:not(:root){overflow:hidden}
 figure{margin:0}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
 fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
 legend{border:0;padding:0}
 button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
 button,input{line-height:normal}
 button,select{text-transform:none}
-button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
+button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
 button[disabled],html input[disabled]{cursor:default}
-input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
-input[type="search"]{-webkit-appearance:textfield;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;box-sizing:content-box}
-input[type="search"]::-webkit-search-cancel-button,input[type="search"]::-webkit-search-decoration{-webkit-appearance:none}
+input[type=checkbox],input[type=radio]{padding:0}
 button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
 textarea{overflow:auto;vertical-align:top}
 table{border-collapse:collapse;border-spacing:0}
-*,*:before,*:after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
+*,::before,::after{box-sizing:border-box}
 html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
 a:hover{cursor:pointer}
 img,object,embed{max-width:100%;height:auto}
 object,embed{height:100%}
@@ -65,19 +60,15 @@ img{-ms-interpolation-mode:bicubic}
 .text-center{text-align:center!important}
 .text-justify{text-align:justify!important}
 .hide{display:none}
-body{-webkit-font-smoothing:antialiased}
 img,object,svg{display:inline-block;vertical-align:middle}
 textarea{height:auto;min-height:50px}
 select{width:100%}
-.center{margin-left:auto;margin-right:auto}
-.spread{width:100%}
-p.lead,.paragraph.lead>p,#preamble>.sectionbody>.paragraph:first-of-type p{font-size:1.21875em;line-height:1.6}
 .subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
 a{color:#2156a5;text-decoration:underline;line-height:inherit}
 a:hover,a:focus{color:#1d4b8f}
-a img{border:none}
-p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+a img{border:0}
+p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
 p aside{font-size:.875em;line-height:1.35;font-style:italic}
 h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
 h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
@@ -86,75 +77,82 @@ h2{font-size:1.6875em}
 h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
 h4,h5{font-size:1.125em}
 h6{font-size:1em}
-hr{border:solid #ddddd8;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
 em,i{font-style:italic;line-height:inherit}
 strong,b{font-weight:bold;line-height:inherit}
 small{font-size:60%;line-height:inherit}
 code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol,ul.no-bullet,ol.no-bullet{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
+ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
 ul.circle{list-style-type:circle}
 ul.disc{list-style-type:disc}
-ul.no-bullet{list-style:none}
+ul.square{list-style-type:square}
+ul.circle ul:not([class]),ul.disc ul:not([class]),ul.square ul:not([class]){list-style:inherit}
 ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
 dl dt{margin-bottom:.3125em;font-weight:bold}
 dl dd{margin-bottom:1.25em}
-abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
-abbr{text-transform:none}
 blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
-blockquote cite:before{content:"\2014 \0020"}
-blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
 blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media only screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
 h1{font-size:2.75em}
 h2{font-size:2.3125em}
 h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
 h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
-table thead,table tfoot{background:#f7f8f7;font-weight:bold}
+table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
+table thead,table tfoot{background:#f7f8f7}
 table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
 table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt,table tr:nth-of-type(even){background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
-body{tab-size:4}
+table tr.even,table tr.alt{background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
 h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
 h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.clearfix:before,.clearfix:after,.float-group:before,.float-group:after{content:" ";display:table}
-.clearfix:after,.float-group:after{clear:both}
-*:not(pre)>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background-color:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
-pre,pre>code{line-height:1.45;color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;text-rendering:optimizeSpeed}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+:not(pre).nobreak{word-wrap:normal}
+:not(pre).nowrap{white-space:nowrap}
+:not(pre).pre-wrap{white-space:pre-wrap}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
+pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
+pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre>code{display:block}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
+em em{font-style:normal}
+strong strong{font-weight:400}
 .keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background-color:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
 .keyseq kbd:first-child{margin-left:0}
 .keyseq kbd:last-child{margin-right:0}
-.menuseq,.menu{color:rgba(0,0,0,.8)}
-b.button:before,b.button:after{position:relative;top:-1px;font-weight:400}
-b.button:before{content:"[";padding:0 3px 0 2px}
-b.button:after{content:"]";padding:0 2px 0 3px}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
 p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header:before,#header:after,#content:before,#content:after,#footnotes:before,#footnotes:after,#footer:before,#footer:after{content:" ";display:table}
-#header:after,#content:after,#footnotes:after,#footer:after{clear:both}
+#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
 #content{margin-top:1.25em}
-#content:before{content:none}
+#content::before{content:none}
 #header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #ddddd8}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #ddddd8;padding-bottom:8px}
-#header .details{border-bottom:1px solid #ddddd8;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child{border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
 #header .details span:first-child{margin-left:-.125em}
 #header .details span.email a{color:rgba(0,0,0,.85)}
 #header .details br{display:none}
-#header .details br+span:before{content:"\00a0\2013\00a0"}
-#header .details br+span.author:before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark:before{content:"\00a0|\00a0"}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
 #header #revnumber{text-transform:capitalize}
-#header #revnumber:after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #ddddd8;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #efefed;padding-bottom:.5em}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
 #toc>ul{margin-left:.125em}
 #toc ul.sectlevel0>li>a{font-style:italic}
 #toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
@@ -163,107 +161,119 @@ p a>code:hover{color:rgba(0,0,0,.9)}
 #toc a{text-decoration:none}
 #toc a:active{text-decoration:underline}
 #toctitle{color:#7a2518;font-size:1.2em}
-@media only screen and (min-width:768px){#toctitle{font-size:1.375em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
 body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background-color:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #efefed;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
 #toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
 #toc.toc2>ul{font-size:.9em;margin-bottom:0}
 #toc.toc2 ul ul{margin-left:0;padding-left:1em}
 #toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
 body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #efefed;left:auto;right:0}}
-@media only screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
 #toc.toc2{width:20em}
 #toc.toc2 #toctitle{font-size:1.375em}
 #toc.toc2>ul{font-size:.95em}
 #toc.toc2 ul ul{padding-left:1.25em}
 body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
 #content #toc>:first-child{margin-top:0}
 #content #toc>:last-child{margin-bottom:0}
-#footer{max-width:100%;background-color:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
+#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
+#content{margin-bottom:.625em}
 .sect1{padding-bottom:.625em}
-@media only screen and (min-width:768px){.sect1{padding-bottom:1.25em}}
-.sect1+.sect1{border-top:1px solid #efefed}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
 #content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor:before,h2>a.anchor:before,h3>a.anchor:before,#toctitle>a.anchor:before,.sidebarblock>.content>.title>a.anchor:before,h4>a.anchor:before,h5>a.anchor:before,h6>a.anchor:before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
 #content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
 #content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
 #content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details{margin-left:1.25rem}
+details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
+details>summary::-webkit-details-marker{display:none}
+details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
+details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
+details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
 .admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock>caption.title{white-space:nowrap;overflow:visible;max-width:0}
-.paragraph.lead>p,#preamble>.sectionbody>.paragraph:first-of-type p{color:rgba(0,0,0,.85)}
-table.tableblock #preamble>.sectionbody>.paragraph:first-of-type p{font-size:inherit}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
 .admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
 .admonitionblock>table td.icon{text-align:center;width:80px}
 .admonitionblock>table td.icon img{max-width:none}
 .admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #ddddd8;color:rgba(0,0,0,.6)}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
 .admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
+.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
+.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
 .sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock pre:not(.highlight),.listingblock pre[class="highlight"],.listingblock pre[class^="highlight "],.listingblock pre.CodeRay,.listingblock pre.prettyprint{background:#f7f7f8}
-.sidebarblock .literalblock pre,.sidebarblock .listingblock pre:not(.highlight),.sidebarblock .listingblock pre[class="highlight"],.sidebarblock .listingblock pre[class^="highlight "],.sidebarblock .listingblock pre.CodeRay,.sidebarblock .listingblock pre.prettyprint{background:#f2f1f1}
-.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;padding:1em;font-size:.8125em}
-.literalblock pre.nowrap,.literalblock pre[class].nowrap,.listingblock pre.nowrap,.listingblock pre[class].nowrap{overflow-x:auto;white-space:pre;word-wrap:normal}
-@media only screen and (min-width:768px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:.90625em}}
-@media only screen and (min-width:1280px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:1em}}
-.literalblock.output pre{color:#f7f7f8;background-color:rgba(0,0,0,.9)}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
+.exampleblock>.content>:first-child,.sidebarblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child,.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
 .listingblock>.content{position:relative}
-.listingblock code[data-lang]:before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:#999}
-.listingblock:hover code[data-lang]:before{display:block}
-.listingblock.terminal pre .command:before{content:attr(data-prompt);padding-right:.5em;color:#999}
-.listingblock.terminal pre .command:not([data-prompt]):before{content:"$"}
-table.pyhltable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.pyhltable td{vertical-align:top;padding-top:0;padding-bottom:0;line-height:1.45}
-table.pyhltable td.code{padding-left:.75em;padding-right:0}
-pre.pygments .lineno,table.pyhltable td:not(.code){color:#999;padding-left:0;padding-right:.5em;border-right:1px solid #ddddd8}
-pre.pygments .lineno{display:inline-block;margin-right:.25em}
-table.pyhltable .linenodiv{background:none!important;padding-right:0!important}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
+pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint li code[data-lang]::before{opacity:1}
+pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
+table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.linenotable td.code{padding-left:.75em}
+table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
+pre.pygments span.linenos{display:inline-block;margin-right:.75em}
 .quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock blockquote p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
 .quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote:before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
 .quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.5em;margin-right:.5ex;text-align:right}
-.quoteblock .quoteblock{margin-left:0;margin-right:0;padding:.5em 0;border-left:3px solid rgba(0,0,0,.6)}
-.quoteblock .quoteblock blockquote{padding:0 0 0 .75em}
-.quoteblock .quoteblock blockquote:before{display:none}
-.verseblock{margin:0 1em 1.25em 1em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
 .verseblock pre strong{font-weight:400}
 .verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
 .quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
 .quoteblock .attribution br,.verseblock .attribution br{display:none}
 .quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract{margin:0 0 1.25em 0;display:block}
-.quoteblock.abstract blockquote,.quoteblock.abstract blockquote p{text-align:left;word-spacing:0}
-.quoteblock.abstract blockquote:before,.quoteblock.abstract blockquote p:first-of-type:before{display:none}
-table.tableblock{max-width:100%;border-collapse:separate}
-table.tableblock td>.paragraph:last-child p>p:last-child,table.tableblock th>p:last-child,table.tableblock td>p:last-child{margin-bottom:0}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
+td.tableblock>.content>:last-child{margin-bottom:-1.25em}
 table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all th.tableblock,table.grid-all td.tableblock{border-width:0 1px 1px 0}
-table.grid-all tfoot>tr>th.tableblock,table.grid-all tfoot>tr>td.tableblock{border-width:1px 1px 0 0}
-table.grid-cols th.tableblock,table.grid-cols td.tableblock{border-width:0 1px 0 0}
-table.grid-all *>tr>.tableblock:last-child,table.grid-cols *>tr>.tableblock:last-child{border-right-width:0}
-table.grid-rows th.tableblock,table.grid-rows td.tableblock{border-width:0 0 1px 0}
-table.grid-all tbody>tr:last-child>th.tableblock,table.grid-all tbody>tr:last-child>td.tableblock,table.grid-all thead:last-child>tr>th.tableblock,table.grid-rows tbody>tr:last-child>th.tableblock,table.grid-rows tbody>tr:last-child>td.tableblock,table.grid-rows thead:last-child>tr>th.tableblock{border-bottom-width:0}
-table.grid-rows tfoot>tr>th.tableblock,table.grid-rows tfoot>tr>td.tableblock{border-width:1px 0 0 0}
+table.grid-all>*>tr>*{border-width:1px}
+table.grid-cols>*>tr>*{border-width:0 1px}
+table.grid-rows>*>tr>*{border-width:1px 0}
 table.frame-all{border-width:1px}
+table.frame-ends{border-width:1px 0}
 table.frame-sides{border-width:0 1px}
-table.frame-topbot{border-width:1px 0}
+table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
+table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
+table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
+table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
+table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
 th.halign-left,td.halign-left{text-align:left}
 th.halign-right,td.halign-right{text-align:right}
 th.halign-center,td.halign-center{text-align:center}
@@ -271,23 +281,24 @@ th.valign-top,td.valign-top{vertical-align:top}
 th.valign-bottom,td.valign-bottom{vertical-align:bottom}
 th.valign-middle,td.valign-middle{vertical-align:middle}
 table thead th,table tfoot th{font-weight:bold}
-tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
+tbody tr th{background:#f7f8f7}
 tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
 p.tableblock>code:only-child{background:none;padding:0}
 p.tableblock{font-size:1em}
-td>div.verse{white-space:pre}
 ol{margin-left:1.75em}
 ul li ol{margin-left:1.5em}
 dl dd{margin-left:1.125em}
 dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.unstyled,ol.unnumbered,ul.checklist,ul.none{list-style-type:none}
-ul.unstyled,ol.unnumbered,ul.checklist{margin-left:.625em}
-ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1em;font-size:.85em}
-ul.checklist li>p:first-child>input[type="checkbox"]:first-child{width:1em;position:relative;top:1px}
-ul.inline{margin:0 auto .625em auto;margin-left:-1.375em;margin-right:0;padding:0;list-style:none;overflow:hidden}
-ul.inline>li{list-style:none;float:left;margin-left:1.375em;display:block}
-ul.inline>li>*{display:block}
+li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+li>p:empty:only-child::before{content:"";display:inline-block}
+ul.checklist>li>p:first-child{margin-left:-1em}
+ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
+ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
 .unstyled dl dt{font-weight:400;font-style:normal}
 ol.arabic{list-style-type:decimal}
 ol.decimal{list-style-type:decimal-leading-zero}
@@ -300,12 +311,14 @@ ol.lowergreek{list-style-type:lower-greek}
 .hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
 td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
 td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+td.hdlist2{word-wrap:anywhere}
 .literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist>table tr>td:first-of-type{padding:0 .75em;line-height:1}
-.colist>table tr>td:last-of-type{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
-.imageblock.left,.imageblock[style*="float: left"]{margin:.25em .625em 1.25em 0}
-.imageblock.right,.imageblock[style*="float: right"]{margin:.25em 0 1.25em .625em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
 .imageblock>.title{margin-bottom:0}
 .imageblock.thumb,.imageblock.th{border-width:6px}
 .imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
@@ -316,15 +329,13 @@ a.image{text-decoration:none;display:inline-block}
 a.image object{pointer-events:none}
 sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
 sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+sup.footnote a:active,sup.footnoteref a:active,#footnotes .footnote a:first-of-type:active{text-decoration:underline}
 #footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em 0;border-width:1px 0 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;text-indent:-1.05em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
 #footnotes .footnote:last-of-type{margin-bottom:0}
 #content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
-.gist .file-data>table td.line-data{width:99%}
 div.unbreakable{page-break-inside:avoid}
 .big{font-size:larger}
 .small{font-size:smaller}
@@ -332,90 +343,96 @@ div.unbreakable{page-break-inside:avoid}
 .overline{text-decoration:overline}
 .line-through{text-decoration:line-through}
 .aqua{color:#00bfbf}
-.aqua-background{background-color:#00fafa}
+.aqua-background{background:#00fafa}
 .black{color:#000}
-.black-background{background-color:#000}
+.black-background{background:#000}
 .blue{color:#0000bf}
-.blue-background{background-color:#0000fa}
+.blue-background{background:#0000fa}
 .fuchsia{color:#bf00bf}
-.fuchsia-background{background-color:#fa00fa}
+.fuchsia-background{background:#fa00fa}
 .gray{color:#606060}
-.gray-background{background-color:#7d7d7d}
+.gray-background{background:#7d7d7d}
 .green{color:#006000}
-.green-background{background-color:#007d00}
+.green-background{background:#007d00}
 .lime{color:#00bf00}
-.lime-background{background-color:#00fa00}
+.lime-background{background:#00fa00}
 .maroon{color:#600000}
-.maroon-background{background-color:#7d0000}
+.maroon-background{background:#7d0000}
 .navy{color:#000060}
-.navy-background{background-color:#00007d}
+.navy-background{background:#00007d}
 .olive{color:#606000}
-.olive-background{background-color:#7d7d00}
+.olive-background{background:#7d7d00}
 .purple{color:#600060}
-.purple-background{background-color:#7d007d}
+.purple-background{background:#7d007d}
 .red{color:#bf0000}
-.red-background{background-color:#fa0000}
+.red-background{background:#fa0000}
 .silver{color:#909090}
-.silver-background{background-color:#bcbcbc}
+.silver-background{background:#bcbcbc}
 .teal{color:#006060}
-.teal-background{background-color:#007d7d}
+.teal-background{background:#007d7d}
 .white{color:#bfbfbf}
-.white-background{background-color:#fafafa}
+.white-background{background:#fafafa}
 .yellow{color:#bfbf00}
-.yellow-background{background-color:#fafa00}
+.yellow-background{background:#fafa00}
 span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
 .admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note:before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip:before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning:before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution:before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important:before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background-color:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
 .conum[data-value] *{color:#fff!important}
 .conum[data-value]+b{display:none}
-.conum[data-value]:after{content:attr(data-value)}
+.conum[data-value]::after{content:attr(data-value)}
 pre .conum[data-value]{position:relative;top:-.125em}
 b.conum *{color:inherit!important}
 .conum:not([data-value]):empty{display:none}
 dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
+h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
 p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
+p,blockquote,dt,td.content,td.hdlist1,span.alt,summary{font-size:1.0625rem}
 p{margin-bottom:1.25rem}
 .sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background-color:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
 .print-only{display:none!important}
-@media print{@page{margin:1.25cm .75cm}
-*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
 a{color:inherit!important;text-decoration:underline!important}
 a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare):after,a[href^="https:"]:not(.bare):after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]:after{content:" (" attr(title) ")"}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]{border-bottom:1px dotted}
+abbr[title]::after{content:" (" attr(title) ")"}
 pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
 thead{display:table-header-group}
 svg{max-width:100%}
 p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
 h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#header,#content,#footnotes,#footer{max-width:none}
 #toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #ddddd8!important;padding-bottom:0!important}
-.sect1{padding-bottom:0!important}
-.sect1+.sect1{border:0!important}
-#header>h1:first-child{margin-top:1.25rem}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
 body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em 0}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
 body.book #header .details{border:0!important;display:block;padding:0!important}
 body.book #header .details span:first-child{margin-left:0!important}
 body.book #header .details br{display:block}
-body.book #header .details br+span:before{content:none!important}
+body.book #header .details br+span::before{content:none!important}
 body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
 body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]:before{display:block}
-#footer{background:none!important;padding:0 .9375em}
-#footer-text{color:rgba(0,0,0,.6)!important;font-size:.9em}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
 .hide-on-print{display:none!important}
 .print-only{display:block!important}
 .hide-for-print{display:none!important}
 .show-for-print{display:inherit!important}}
+@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
 </style>
 </head>
 <body class="article">
@@ -428,26 +445,53 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="toctitle">Table of Contents</div>
 <ul class="sectlevel1">
 <li><a href="#_install">1. Install</a></li>
-<li><a href="#_usage">2. Usage</a></li>
-<li><a href="#_make_targets">3. make targets</a>
+<li><a href="#_development">2. Development</a></li>
+<li><a href="#_usage">3. Usage</a></li>
+<li><a href="#_make_targets">4. make targets</a>
 <ul class="sectlevel2">
-<li><a href="#_html">3.1. html</a></li>
-<li><a href="#_test">3.2. test</a></li>
-<li><a href="#_testdeps">3.3. testdeps</a></li>
-<li><a href="#_results">3.4. results</a></li>
-<li><a href="#_tag">3.5. tag</a></li>
-<li><a href="#_dist">3.6. dist</a></li>
-<li><a href="#_pgxntool_sync">3.7. pgxntool-sync</a></li>
+<li><a href="#_html">4.1. html</a></li>
+<li><a href="#_test">4.2. test</a></li>
+<li><a href="#_test_build">4.3. test-build</a></li>
+<li><a href="#_testinstall">4.4. test/install</a></li>
+<li><a href="#_testdeps">4.5. testdeps</a></li>
+<li><a href="#_results">4.6. results</a></li>
+<li><a href="#_tag">4.7. tag</a></li>
+<li><a href="#_dist">4.8. dist</a></li>
+<li><a href="#_pgxntool_sync">4.9. pgxntool-sync</a></li>
+<li><a href="#_distclean">4.10. distclean</a></li>
+<li><a href="#_pgtle">4.11. pgtle</a></li>
+<li><a href="#_check_pgtle">4.12. check-pgtle</a></li>
+<li><a href="#_run_pgtle">4.13. run-pgtle</a></li>
 </ul>
 </li>
-<li><a href="#_document_handling">4. Document Handling</a>
+<li><a href="#_version_specific_sql_files">5. Version-Specific SQL Files</a>
 <ul class="sectlevel2">
-<li><a href="#_document_variables">4.1. Document Variables</a></li>
-<li><a href="#_document_rules">4.2. Document Rules</a></li>
-<li><a href="#_the_docs_variable">4.3. The DOCS variable</a></li>
+<li><a href="#_how_version_files_are_generated">5.1. How Version Files Are Generated</a></li>
+<li><a href="#_what_controls_the_version_number">5.2. What Controls the Version Number</a></li>
+<li><a href="#_committing_version_files">5.3. Committing Version Files</a></li>
+<li><a href="#_alternative_ignoring_version_files">5.4. Alternative: Ignoring Version Files</a></li>
+<li><a href="#_distribution_inclusion">5.5. Distribution Inclusion</a></li>
+<li><a href="#_multiple_versions">5.6. Multiple Versions</a></li>
 </ul>
 </li>
-<li><a href="#_copyright">5. Copyright</a></li>
+<li><a href="#_document_handling">6. Document Handling</a>
+<ul class="sectlevel2">
+<li><a href="#_document_variables">6.1. Document Variables</a></li>
+<li><a href="#_document_rules">6.2. Document Rules</a></li>
+<li><a href="#_the_docs_variable">6.3. The DOCS variable</a></li>
+</ul>
+</li>
+<li><a href="#_pg_tle_support">7. pg_tle Support</a>
+<ul class="sectlevel2">
+<li><a href="#_what_is_pg_tle">7.1. What is pg_tle?</a></li>
+<li><a href="#_quick_start">7.2. Quick Start</a></li>
+<li><a href="#_version_groupings">7.3. Version Groupings</a></li>
+<li><a href="#_installation_example">7.4. Installation Example</a></li>
+<li><a href="#_advanced_usage">7.5. Advanced Usage</a></li>
+<li><a href="#_how_it_works">7.6. How It Works</a></li>
+<li><a href="#_troubleshooting">7.7. Troubleshooting</a></li>
+</ul>
+</li>
 </ul>
 </div>
 </div>
@@ -466,7 +510,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div>
 </div>
 <div class="sect1">
-<h2 id="_install"><a class="anchor" href="#_install"></a>1. Install</h2>
+<h2 id="_install"><a class="anchor" href="#_install"></a><a class="link" href="#_install">1. Install</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>This assumes that you&#8217;ve already initialized your extension in git.</p>
@@ -495,7 +539,15 @@ pgxntool/setup.sh</pre>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_usage"><a class="anchor" href="#_usage"></a>2. Usage</h2>
+<h2 id="_development"><a class="anchor" href="#_development"></a><a class="link" href="#_development">2. Development</a></h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>If you want to contribute to pgxntool development, work from the <a href="https://github.com/decibel/pgxntool-test">pgxntool-test</a> repository, not from this repository. That repository contains the test infrastructure and development tools needed to validate changes to pgxntool. This repository contains only the framework files that get embedded into extension projects via <code>git subtree</code>.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_usage"><a class="anchor" href="#_usage"></a><a class="link" href="#_usage">3. Usage</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>Typically, you can just create a simple Makefile that does nothing but include base.mk:</p>
@@ -508,7 +560,7 @@ pgxntool/setup.sh</pre>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_make_targets"><a class="anchor" href="#_make_targets"></a>3. make targets</h2>
+<h2 id="_make_targets"><a class="anchor" href="#_make_targets"></a><a class="link" href="#_make_targets">4. make targets</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>These are the make targets that are provided by base.mk</p>
@@ -526,19 +578,214 @@ all the targets normally provided by Postgres <a href="http://www.postgresql.org
 </table>
 </div>
 <div class="sect2">
-<h3 id="_html"><a class="anchor" href="#_html"></a>3.1. html</h3>
+<h3 id="_html"><a class="anchor" href="#_html"></a><a class="link" href="#_html">4.1. html</a></h3>
 <div class="paragraph">
 <p>This will build any .html files that can be created. See <a href="#_Document_Handling">[_Document_Handling]</a>.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_test"><a class="anchor" href="#_test"></a>3.2. test</h3>
+<h3 id="_test"><a class="anchor" href="#_test"></a><a class="link" href="#_test">4.2. test</a></h3>
 <div class="paragraph">
 <p>Runs unit tests via the PGXS <code>installcheck</code> target. Unlike a simple <code>make installcheck</code> though, the <code>test</code> rule has the following prerequisites: clean testdeps install installcheck. All of those are PGXS rules, except for <code>testdeps</code>.</p>
 </div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+While you can still run <code>make installcheck</code> or any other valid PGXS make target directly, it&#8217;s recommended to use <code>make test</code> when using pgxntool. The <code>test</code> target ensures clean builds, proper test isolation, and correct dependency installation.
+</td>
+</tr>
+</table>
+</div>
 </div>
 <div class="sect2">
-<h3 id="_testdeps"><a class="anchor" href="#_testdeps"></a>3.3. testdeps</h3>
+<h3 id="_test_build"><a class="anchor" href="#_test_build"></a><a class="link" href="#_test_build">4.3. test-build</a></h3>
+<div class="paragraph">
+<p>Validates that extension SQL files are syntactically correct before running the full test suite. This feature runs SQL files from <code>test/build/</code> through <code>pg_regress</code>, providing better error messages than <code>CREATE EXTENSION</code> failures when there are syntax errors in your extension code.</p>
+</div>
+<div class="paragraph">
+<p><strong>How it works:</strong></p>
+</div>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>Place SQL files in <code>test/build/*.sql</code></p>
+</li>
+<li>
+<p>Place expected output in <code>test/build/expected/*.out</code></p>
+</li>
+<li>
+<p>These files run through <code>pg_regress</code> before <code>make test</code> runs the main test suite</p>
+</li>
+<li>
+<p>If any build test fails, the test run stops immediately with clear error messages</p>
+</li>
+</ol>
+</div>
+<div class="paragraph">
+<p><strong>Directory structure:</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>test/build/
+├── *.sql              # SQL test files (checked in)
+├── expected/          # Expected output files (checked in)
+│   └── *.out
+└── sql/               # GENERATED - do not edit or check in
+    └── *.sql          # Synced from *.sql above</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The <code>sql/</code> subdirectory is generated automatically by <code>make test-build</code>. It is listed in <code>.gitignore</code> and removed by <code>make clean</code>. Do not place files directly in <code>test/build/sql/</code>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Configuration:</strong></p>
+</div>
+<div class="paragraph">
+<p>The feature auto-detects based on whether <code>test/build/*.sql</code> files exist:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Files present → feature enabled automatically</p>
+</li>
+<li>
+<p>No files → feature disabled (no impact on existing projects)</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>You can override auto-detection by setting <code>PGXNTOOL_ENABLE_TEST_BUILD</code>:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre># In your Makefile
+PGXNTOOL_ENABLE_TEST_BUILD = yes  # or no</pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>Example: Validate extension SQL compiles</strong></p>
+</div>
+<div class="paragraph">
+<p>Create <code>test/build/build.sql</code> to run your extension&#8217;s SQL directly:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>\set ECHO none
+-- Sets ON_ERROR_STOP, VERBOSITY verbose, and ON_ERROR_ROLLBACK
+\i test/pgxntool/psql.sql
+-- Suppress column headers and row counts for cleaner expected output
+\t
+
+BEGIN;
+SET client_min_messages = WARNING;
+
+-- Install dependencies your extension requires
+CREATE EXTENSION IF NOT EXISTS pgtap CASCADE;
+
+-- Clean slate
+DROP EXTENSION IF EXISTS myext;
+DROP SCHEMA IF EXISTS myext;
+CREATE SCHEMA myext;
+
+-- Run the actual extension SQL (not CREATE EXTENSION)
+-- psql.sql above ensures errors abort immediately with clear messages
+\i sql/myext.sql
+
+-- If we get here, the build succeeded; ON_ERROR_STOP would have aborted on any error above
+\echo # BUILD TEST SUCCEEDED
+ROLLBACK;</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This approach catches SQL syntax errors <strong>before</strong> running <code>CREATE EXTENSION</code>, giving clearer error messages with line numbers. The <code>ROLLBACK</code> ensures nothing persists—this is purely validation.</p>
+</div>
+<div class="paragraph">
+<p><strong>Why use <code>\i</code> instead of <code>CREATE EXTENSION</code>?</strong></p>
+</div>
+<div class="paragraph">
+<p>When <code>CREATE EXTENSION</code> fails, PostgreSQL shows only "syntax error" with limited context. Running the SQL directly via <code>\i</code> shows the exact line and position of errors, making debugging much faster.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_testinstall"><a class="anchor" href="#_testinstall"></a><a class="link" href="#_testinstall">4.4. test/install</a></h3>
+<div class="paragraph">
+<p>Runs setup files before the main test suite within the same <code>pg_regress</code> invocation. This allows expensive one-time operations (like extension installation) to set up state that persists into the regular test files.</p>
+</div>
+<div class="paragraph">
+<p><strong>How it works:</strong></p>
+</div>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>Place SQL files in <code>test/install/*.sql</code></p>
+</li>
+<li>
+<p>Place expected output alongside as <code>test/install/*.out</code></p>
+</li>
+<li>
+<p>A schedule file is auto-generated that lists install files with <code>../install/</code> relative paths</p>
+</li>
+<li>
+<p><code>pg_regress</code> processes the install schedule first, then runs regular test files — all in one invocation, so database state persists</p>
+</li>
+</ol>
+</div>
+<div class="paragraph">
+<p><strong>Directory structure:</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>test/install/
+├── *.sql              # SQL setup files (checked in)
+├── *.out              # Expected output (checked in, alongside .sql)
+├── .gitignore         # Ignores pg_regress artifacts (*.out.diff)
+└── schedule           # GENERATED - auto-created by make</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The <code>schedule</code> file is generated automatically and listed in <code>.gitignore</code>. Do not edit it.</p>
+</div>
+<div class="paragraph">
+<p><strong>Configuration:</strong></p>
+</div>
+<div class="paragraph">
+<p>The feature auto-detects based on whether <code>test/install/*.sql</code> files exist:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Files present → feature enabled automatically</p>
+</li>
+<li>
+<p>No files → feature disabled (no impact on existing projects)</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>You can override auto-detection by setting <code>PGXNTOOL_ENABLE_TEST_INSTALL</code>:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre># In your Makefile
+PGXNTOOL_ENABLE_TEST_INSTALL = yes  # or no</pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>Why this is useful:</strong></p>
+</div>
+<div class="paragraph">
+<p>Without <code>test/install</code>, each test file typically needs to run <code>CREATE EXTENSION</code> in its setup, which adds overhead and doesn&#8217;t allow validating the installation step separately. With <code>test/install</code>, setup runs once before all tests, and any state it creates (tables, extensions, etc.) is available to every subsequent test file.</p>
+</div>
+<div class="paragraph">
+<p><strong>Key detail:</strong> Install files and regular tests run in a single <code>pg_regress</code> invocation. This means the database is NOT dropped between install and test phases — state created by install files persists into the main test suite.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_testdeps"><a class="anchor" href="#_testdeps"></a><a class="link" href="#_testdeps">4.5. testdeps</a></h3>
 <div class="paragraph">
 <p>This rule allows you to ensure certain actions have taken place before running tests. By default it has a single prerequisite, <code>pgtap</code>, which will attempt to install <a href="http://pgtap.org">pgtap</a> from PGXN. This depneds on having the pgxn client installed.</p>
 </div>
@@ -574,16 +821,71 @@ It will probably cause problems if you try to create a <code>testdeps</code> rul
 </div>
 </div>
 <div class="sect2">
-<h3 id="_results"><a class="anchor" href="#_results"></a>3.4. results</h3>
+<h3 id="_results"><a class="anchor" href="#_results"></a><a class="link" href="#_results">4.6. results</a></h3>
 <div class="paragraph">
-<p>Because <code>make test</code> ultimately runs <code>installcheck</code>, it&#8217;s using the Postgres test suite. Unfortunately, that suite is based on running <code>diff</code> between a raw output file and expected results. I <strong>STRONGLY</strong> recommend you use <a href="http://pgtap.org">pgTap</a> instead! The extra effort of learning pgTap will quickly pay for itself. <a href="https://github.com/decibel/trunklet-format/blob/master/test/sql/base.sql">This example</a> might help get you started.</p>
+<p>Because <code>make test</code> ultimately runs <code>installcheck</code>, it&#8217;s using the Postgres test suite. Unfortunately, that suite is based on running <code>diff</code> between a raw output file and expected results. I <strong>STRONGLY</strong> recommend you use <a href="http://pgtap.org">pgTap</a> instead! With pgTap, it&#8217;s MUCH easier to determine whether a test is passing or not - tests explicitly pass or fail rather than requiring you to examine diff output. The extra effort of learning pgTap will quickly pay for itself. <a href="https://github.com/decibel/trunklet-format/blob/master/test/sql/base.sql">This example</a> might help get you started.</p>
 </div>
 <div class="paragraph">
 <p>No matter what method you use, once you know that all your tests are passing correctly, you need to create or update the test output expected files. <code>make results</code> does that for you.</p>
 </div>
+<div class="admonitionblock important">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Important</div>
+</td>
+<td class="content">
+<strong><code>make results</code> requires manual verification first</strong>. The correct workflow is:
+</td>
+</tr>
+</table>
+</div>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>Run <code>make test</code> and examine the diff output</p>
+</li>
+<li>
+<p>Manually verify that the differences are correct and expected</p>
+</li>
+<li>
+<p>Only then run <code>make results</code> to update the expected output files in <code>test/expected/</code></p>
+</li>
+</ol>
+</div>
+<div class="paragraph">
+<p>Never run <code>make results</code> without first verifying the test changes are correct. The <code>results</code> target copies files from <code>test/results/</code> to <code>test/expected/</code>, so running it blindly will make incorrect output become the new expected behavior.</p>
+</div>
+<div class="sect3">
+<h4 id="_verify_results_safeguard"><a class="anchor" href="#_verify_results_safeguard"></a><a class="link" href="#_verify_results_safeguard">4.6.1. verify-results safeguard</a></h4>
+<div class="paragraph">
+<p>By default, <code>make results</code> will refuse to run if <code>test/results/regression.diffs</code> exists (indicating failing tests). This prevents accidentally updating expected files with incorrect output.</p>
+</div>
+<div class="paragraph">
+<p>If tests are failing, you&#8217;ll see:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>ERROR: Tests are failing. Cannot run 'make results'.
+Fix test failures first, then run 'make results'.</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>To disable this safeguard (not recommended):</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre># In your Makefile
+PGXNTOOL_ENABLE_VERIFY_RESULTS = no
+
+# Or on the command line
+make PGXNTOOL_ENABLE_VERIFY_RESULTS=no results</pre>
+</div>
+</div>
+</div>
 </div>
 <div class="sect2">
-<h3 id="_tag"><a class="anchor" href="#_tag"></a>3.5. tag</h3>
+<h3 id="_tag"><a class="anchor" href="#_tag"></a><a class="link" href="#_tag">4.7. tag</a></h3>
 <div class="paragraph">
 <p><code>make tag</code> will create a git branch for the current version of your extension, as determined by the META.json file. The reason to do this is so you can always refer to the exact code that went into a released version.</p>
 </div>
@@ -604,7 +906,7 @@ You will be very unhappy if you forget to update the .control file for your exte
 </div>
 </div>
 <div class="sect2">
-<h3 id="_dist"><a class="anchor" href="#_dist"></a>3.6. dist</h3>
+<h3 id="_dist"><a class="anchor" href="#_dist"></a><a class="link" href="#_dist">4.8. dist</a></h3>
 <div class="paragraph">
 <p><code>make dist</code> will create a .zip file for your current version that you can upload to PGXN. The file is named after the PGXN name and version (the top-level "name" and "version" attributes in META.json). The .zip file is placed in the <strong>parent</strong> directory so as not to clutter up your git repo.</p>
 </div>
@@ -622,7 +924,7 @@ Part of the <code>clean</code> recipe is cleaning up these .zip files. If you ac
 </div>
 </div>
 <div class="sect2">
-<h3 id="_pgxntool_sync"><a class="anchor" href="#_pgxntool_sync"></a>3.7. pgxntool-sync</h3>
+<h3 id="_pgxntool_sync"><a class="anchor" href="#_pgxntool_sync"></a><a class="link" href="#_pgxntool_sync">4.9. pgxntool-sync</a></h3>
 <div class="paragraph">
 <p>This rule will pull down the latest released version of PGXNtool via <code>git subtree pull</code>.</p>
 </div>
@@ -651,10 +953,230 @@ There is also a <code>pgxntool-sync-%</code> rule if you need to do more advance
 </table>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_distclean"><a class="anchor" href="#_distclean"></a><a class="link" href="#_distclean">4.10. distclean</a></h3>
+<div class="paragraph">
+<p><code>make distclean</code> removes generated configuration files (<code>META.json</code>, <code>meta.mk</code>, <code>control.mk</code>) that survive a normal <code>make clean</code>.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+PGXS doesn&#8217;t provide any special support for <code>distclean</code> — its built-in <code>distclean</code> target simply depends on <code>clean</code>. PGXNtool uses its own <code>PGXNTOOL_distclean</code> variable to track files that should only be removed by <code>distclean</code>, not <code>clean</code>.
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>If your extension generates additional files that should be removed by <code>distclean</code> but not <code>clean</code>, you can add them:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>PGXNTOOL_distclean += my_generated_config.mk</pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_pgtle"><a class="anchor" href="#_pgtle"></a><a class="link" href="#_pgtle">4.11. pgtle</a></h3>
+<div class="paragraph">
+<p>Generates pg_tle (Trusted Language Extensions) registration SQL files for deploying extensions in managed environments like AWS RDS/Aurora. See <a href="#_pg_tle_Support">[_pg_tle_Support]</a> for complete documentation.</p>
+</div>
+<div class="paragraph">
+<p><code>make pgtle</code> generates SQL files in <code>pg_tle/</code> subdirectories organized by pg_tle version ranges. For version range details, see <code>pgtle_versions.md</code>.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_check_pgtle"><a class="anchor" href="#_check_pgtle"></a><a class="link" href="#_check_pgtle">4.12. check-pgtle</a></h3>
+<div class="paragraph">
+<p>Checks if pg_tle is installed and reports the version. This target:
+- Reports the version from <code>pg_extension</code> if <code>CREATE EXTENSION pg_tle</code> has been run in the database
+- Errors if pg_tle is not available in the cluster</p>
+</div>
+<div class="paragraph">
+<p>This target assumes <code>PG*</code> environment variables are configured for <code>psql</code> connectivity.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>make check-pgtle</pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_run_pgtle"><a class="anchor" href="#_run_pgtle"></a><a class="link" href="#_run_pgtle">4.13. run-pgtle</a></h3>
+<div class="paragraph">
+<p>Registers all extensions with pg_tle by executing the generated pg_tle registration SQL files in a PostgreSQL database. This target:
+- Requires pg_tle extension to be installed (checked via <code>check-pgtle</code>)
+- Uses <code>pgtle.sh</code> to determine which version range directory to use based on the installed pg_tle version
+- Runs all generated SQL files via <code>psql</code> to register your extensions with pg_tle</p>
+</div>
+<div class="paragraph">
+<p>This target assumes that running <code>psql</code> without any arguments will connect to the desired database. You can control this by setting the various PG* environment variables (and possibly using the <code>.pgpassword</code> file). See the PostgreSQL documentation for more details.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+The <code>pgtle</code> target is a dependency, so <code>make run-pgtle</code> will automatically generate the SQL files if needed.
+</td>
+</tr>
+</table>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>make run-pgtle</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>After running <code>make run-pgtle</code>, you can create your extension in the database:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>CREATE EXTENSION "your-extension-name";</pre>
+</div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_document_handling"><a class="anchor" href="#_document_handling"></a>4. Document Handling</h2>
+<h2 id="_version_specific_sql_files"><a class="anchor" href="#_version_specific_sql_files"></a><a class="link" href="#_version_specific_sql_files">5. Version-Specific SQL Files</a></h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>PGXNtool automatically generates version-specific SQL files from your base SQL file. These files follow the pattern <code>sql/{extension}--{version}.sql</code> and are used by PostgreSQL&#8217;s extension system to install specific versions of your extension.</p>
+</div>
+<div class="sect2">
+<h3 id="_how_version_files_are_generated"><a class="anchor" href="#_how_version_files_are_generated"></a><a class="link" href="#_how_version_files_are_generated">5.1. How Version Files Are Generated</a></h3>
+<div class="paragraph">
+<p>When you run <code>make</code> (or <code>make all</code>), PGXNtool:</p>
+</div>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>Reads your <code>META.json</code> file to determine the extension version from <code>provides.{extension}.version</code></p>
+</li>
+<li>
+<p>Generates a Makefile rule that copies your base SQL file (<code>sql/{extension}.sql</code>) to the version-specific file (<code>sql/{extension}--{version}.sql</code>)</p>
+</li>
+<li>
+<p>Executes this rule, creating the version-specific file with a header comment indicating it&#8217;s auto-generated</p>
+</li>
+</ol>
+</div>
+<div class="paragraph">
+<p>For example, if your <code>META.json</code> contains:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>"provides": {
+  "myext": {
+    "version": "1.2.3",
+    ...
+  }
+}</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Running <code>make</code> will create <code>sql/myext&#8212;&#8203;1.2.3.sql</code> by copying <code>sql/myext.sql</code>.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_what_controls_the_version_number"><a class="anchor" href="#_what_controls_the_version_number"></a><a class="link" href="#_what_controls_the_version_number">5.2. What Controls the Version Number</a></h3>
+<div class="paragraph">
+<p>The version number comes from <code>META.json</code> → <code>provides.{extension}.version</code>, <strong>not</strong> from your <code>.control</code> file&#8217;s <code>default_version</code> field. The <code>.control</code> file&#8217;s <code>default_version</code> is used by PostgreSQL to determine which version to install by default, but the actual version-specific file that gets generated is determined by what&#8217;s in <code>META.json</code>.</p>
+</div>
+<div class="paragraph">
+<p>To change the version of your extension:
+1. Update <code>provides.{extension}.version</code> in <code>META.json</code>
+2. Run <code>make</code> to regenerate the version-specific file
+3. Update <code>default_version</code> in your <code>.control</code> file to match (if needed)</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_committing_version_files"><a class="anchor" href="#_committing_version_files"></a><a class="link" href="#_committing_version_files">5.3. Committing Version Files</a></h3>
+<div class="paragraph">
+<p>Version-specific SQL files are now treated as permanent files that should be committed to your repository. This makes it much easier to test updates to extensions, as you can see exactly what SQL was included in each version.</p>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Important</div>
+</td>
+<td class="content">
+These files are auto-generated and include a header comment warning not to edit them. Any manual changes will be overwritten the next time you run <code>make</code>. To modify the extension, edit the base SQL file (<code>sql/{extension}.sql</code>) instead.
+</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_alternative_ignoring_version_files"><a class="anchor" href="#_alternative_ignoring_version_files"></a><a class="link" href="#_alternative_ignoring_version_files">5.4. Alternative: Ignoring Version Files</a></h3>
+<div class="paragraph">
+<p>If you prefer not to commit version-specific SQL files, you must add them to your <code>.gitignore</code> to prevent <code>make dist</code> from failing due to untracked files. Add the following to your <code>.gitignore</code>:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre># Auto-generated version-specific SQL files (if not committing them)
+sql/*--*.sql
+!sql/*--*--*.sql</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The second line (<code>!sql/<strong>--</strong>--*.sql</code>) ensures that upgrade scripts (which contain two version numbers and should be manually written) are still tracked.</p>
+</div>
+<div class="admonitionblock warning">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Warning</div>
+</td>
+<td class="content">
+If you ignore version files instead of committing them, they will NOT be included in your PGXN distribution (<code>make dist</code> uses <code>git archive</code>, which only includes tracked files). This means users installing your extension from PGXN will need <code>make</code> and PGXS available to build the extension - they cannot simply copy the SQL files into their PostgreSQL installation. For maximum compatibility, we recommend committing version files.
+</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_distribution_inclusion"><a class="anchor" href="#_distribution_inclusion"></a><a class="link" href="#_distribution_inclusion">5.5. Distribution Inclusion</a></h3>
+<div class="paragraph">
+<p>Version-specific files are included in distributions created by <code>make dist</code> only if they are committed to git. Since <code>make dist</code> uses <code>git archive</code>, only tracked files are included in the distribution archive.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_multiple_versions"><a class="anchor" href="#_multiple_versions"></a><a class="link" href="#_multiple_versions">5.6. Multiple Versions</a></h3>
+<div class="paragraph">
+<p>If you need to support multiple versions of your extension:</p>
+</div>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>Create additional version-specific files manually (e.g., <code>sql/myext&#8212;&#8203;1.0.0.sql</code>, <code>sql/myext&#8212;&#8203;1.1.0.sql</code>)</p>
+</li>
+<li>
+<p>Create upgrade scripts for version transitions (e.g., <code>sql/myext&#8212;&#8203;1.0.0&#8212;&#8203;1.1.0.sql</code>)</p>
+</li>
+<li>
+<p>Update <code>META.json</code> to reflect the current version you&#8217;re working on</p>
+</li>
+<li>
+<p>Commit all version files and upgrade scripts to your repository</p>
+</li>
+</ol>
+</div>
+<div class="paragraph">
+<p>The version file for the current version (specified in <code>META.json</code>) will be automatically regenerated when you run <code>make</code>, but other version files you create manually will be preserved.</p>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_document_handling"><a class="anchor" href="#_document_handling"></a><a class="link" href="#_document_handling">6. Document Handling</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>PGXNtool supports generation and installation of document files. There are several variables and rules that control this behavior.</p>
@@ -665,7 +1187,7 @@ That way users will have these files installed when they install your extension.
 If any generated files are missing (or out-of-date) during installation, PGXNtool will build them if Asciidoc is present on the system.</p>
 </div>
 <div class="sect2">
-<h3 id="_document_variables"><a class="anchor" href="#_document_variables"></a>4.1. Document Variables</h3>
+<h3 id="_document_variables"><a class="anchor" href="#_document_variables"></a><a class="link" href="#_document_variables">6.1. Document Variables</a></h3>
 <div class="dlist">
 <dl>
 <dt class="hdlist1">DOC_DIRS</dt>
@@ -691,7 +1213,7 @@ If not set PGXNtool will search for first <code>asciidoctor</code>, then <code>a
 <dt class="hdlist1">ASCIIDOC_EXTS</dt>
 <dd>
 <p>File extensions to consider as Asciidoc.
-Defined as <code>+= adoc asciidoc</code>.</p>
+Defined as <code>+= adoc asciidoc asc</code>.</p>
 </dd>
 <dt class="hdlist1">ASCIIDOC_FILES</dt>
 <dd>
@@ -712,7 +1234,7 @@ The result is appended to <code>ASCIIDOC_HTML</code> using <code>+=</code>.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_document_rules"><a class="anchor" href="#_document_rules"></a>4.2. Document Rules</h3>
+<h3 id="_document_rules"><a class="anchor" href="#_document_rules"></a><a class="link" href="#_document_rules">6.2. Document Rules</a></h3>
 <div class="paragraph">
 <p>If Asciidoc is found (or <code>$(ASCIIDOC)</code> is set), the <code>html</code> rule will be added as a prerequisite to the <code>install</code> and <code>installchec</code> rules.
 That will ensure that docs are generated for install and test, but only if Asciidoc is available.
@@ -730,7 +1252,7 @@ These rules are generated from <code>ASCIIDOC_template</code>:</p>
 <div class="title">ASCIIDOC_template</div>
 <div class="content">
 <pre class="highlight"><code class="language-Makefile" data-lang="Makefile">define ASCIIDOC_template
-%.html: %.$(1) <b class="conum">(1)</b>
+%.html: %.$(1) # <b class="conum">(1)</b>
 ifndef ASCIIDOC
 	$$(warning Could not find "asciidoc" or "asciidoctor". Add one of them to your PATH,)
 	$$(warning or set ASCIIDOC to the correct location.)
@@ -754,7 +1276,7 @@ On a normal user system that should never happen, because the <code>html</code> 
 </div>
 </div>
 <div class="sect2">
-<h3 id="_the_docs_variable"><a class="anchor" href="#_the_docs_variable"></a>4.3. The DOCS variable</h3>
+<h3 id="_the_docs_variable"><a class="anchor" href="#_the_docs_variable"></a><a class="link" href="#_the_docs_variable">6.3. The DOCS variable</a></h3>
 <div class="paragraph">
 <p>This variable has special meaning to PGXS.
 See the Postgres documentation for full details.</p>
@@ -782,10 +1304,189 @@ Because of this, <code>base.mk</code> will forcibly define it to be NULL if it&#
 </div>
 </div>
 <div class="sect1">
-<h2 id="_copyright"><a class="anchor" href="#_copyright"></a>5. Copyright</h2>
+<h2 id="_pg_tle_support"><a class="anchor" href="#_pg_tle_support"></a><a class="link" href="#_pg_tle_support">7. pg_tle Support</a></h2>
 <div class="sectionbody">
+<div id="_pg_tle_Support" class="paragraph">
+<p>pgxntool can generate <a href="https://github.com/aws/pg_tle">pg_tle (Trusted Language Extensions)</a> registration SQL for deploying PostgreSQL extensions in managed environments like AWS RDS and Aurora where filesystem access is not available.</p>
+</div>
 <div class="paragraph">
-<p>Copyright (c) 2015 Jim Nasby &lt;<a href="mailto:Jim.Nasby@BlueTreble.com">Jim.Nasby@BlueTreble.com</a>&gt;</p>
+<p>For make targets, see: <a href="#_pgtle">pgtle</a>, <a href="#_check_pgtle">check-pgtle</a>, <a href="#_run_pgtle">run-pgtle</a>.</p>
+</div>
+<div class="sect2">
+<h3 id="_what_is_pg_tle"><a class="anchor" href="#_what_is_pg_tle"></a><a class="link" href="#_what_is_pg_tle">7.1. What is pg_tle?</a></h3>
+<div class="paragraph">
+<p>pg_tle is an AWS open-source framework that enables developers to create and deploy PostgreSQL extensions without filesystem access. Traditional PostgreSQL extensions require <code>.control</code> and <code>.sql</code> files on the filesystem, which isn&#8217;t possible in managed services like RDS and Aurora.</p>
+</div>
+<div class="paragraph">
+<p>pg_tle solves this by:
+- Storing extension metadata and SQL in database tables
+- Using the <code>pgtle_admin</code> role for administrative operations
+- Enabling <code>CREATE EXTENSION</code> to work in managed environments</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_quick_start"><a class="anchor" href="#_quick_start"></a><a class="link" href="#_quick_start">7.2. Quick Start</a></h3>
+<div class="paragraph">
+<p>Generate pg_tle registration SQL for your extension:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>make pgtle</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This creates files in <code>pg_tle/</code> subdirectories organized by pg_tle version ranges. See <code>pgtle_versions.md</code> for complete version range details and API compatibility boundaries.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_version_groupings"><a class="anchor" href="#_version_groupings"></a><a class="link" href="#_version_groupings">7.3. Version Groupings</a></h3>
+<div class="paragraph">
+<p>pgxntool creates different sets of files for different pg_tle versions to handle backward-incompatible API changes. Each version boundary represents a change to pg_tle&#8217;s API functions that we use.</p>
+</div>
+<div class="paragraph">
+<p>For details on version boundaries and API changes, see <code>pgtle_versions.md</code>.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_installation_example"><a class="anchor" href="#_installation_example"></a><a class="link" href="#_installation_example">7.4. Installation Example</a></h3>
+<div class="admonitionblock important">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Important</div>
+</td>
+<td class="content">
+This is only a basic example. Always refer to the <a href="https://github.com/aws/pg_tle">main pg_tle documentation</a> for complete installation instructions and best practices.
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>Basic installation steps:</p>
+</div>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>Ensure pg_tle is installed and grant the <code>pgtle_admin</code> role to your user</p>
+</li>
+<li>
+<p>Generate and run the pg_tle registration SQL files:</p>
+<div class="listingblock">
+<div class="content">
+<pre>make run-pgtle</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This automatically detects your pg_tle version and runs the appropriate SQL files. See <code>pgtle_versions.md</code> for version range details.</p>
+</div>
+</li>
+<li>
+<p>Create your extension: <code>CREATE EXTENSION myextension;</code></p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_advanced_usage"><a class="anchor" href="#_advanced_usage"></a><a class="link" href="#_advanced_usage">7.5. Advanced Usage</a></h3>
+<div class="sect3">
+<h4 id="_multi_extension_projects"><a class="anchor" href="#_multi_extension_projects"></a><a class="link" href="#_multi_extension_projects">7.5.1. Multi-Extension Projects</a></h4>
+<div class="paragraph">
+<p>If your project has multiple extensions (multiple <code>.control</code> files), <code>make pgtle</code> generates files for all of them:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>myproject/
+├── ext1.control
+├── ext2.control
+└── pg_tle/
+    ├── 1.0.0-1.5.0/
+    │   ├── ext1.sql
+    │   └── ext2.sql
+    └── 1.5.0+/
+        ├── ext1.sql
+        └── ext2.sql</pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_how_it_works"><a class="anchor" href="#_how_it_works"></a><a class="link" href="#_how_it_works">7.6. How It Works</a></h3>
+<div class="paragraph">
+<p><code>make pgtle</code> does the following:</p>
+</div>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>Parses control file(s): Extracts <code>comment</code>, <code>default_version</code>, <code>requires</code>, and <code>schema</code> fields</p>
+</li>
+<li>
+<p>Discovers SQL files: Finds all versioned files (<code>sql/{ext}--{version}.sql</code>) and upgrade scripts (<code>sql/{ext}--{ver1}--{ver2}.sql</code>)</p>
+</li>
+<li>
+<p>Wraps SQL content: Uses a fixed dollar-quote delimiter (<code>$<em>pgtle_wrap_delimiter</em>$</code>) to wrap SQL for pg_tle functions</p>
+</li>
+<li>
+<p>Generates registration SQL: Creates <code>pgtle.install_extension()</code> calls for each version, <code>pgtle.install_update_path()</code> for upgrades, and <code>pgtle.set_default_version()</code> for the default</p>
+</li>
+<li>
+<p>Version-specific output: Generates separate files for different pg_tle capability levels</p>
+</li>
+</ol>
+</div>
+<div class="paragraph">
+<p>Each generated SQL file is wrapped in a transaction (<code>BEGIN;</code> &#8230;&#8203; <code>COMMIT;</code>) to ensure atomic installation.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_troubleshooting"><a class="anchor" href="#_troubleshooting"></a><a class="link" href="#_troubleshooting">7.7. Troubleshooting</a></h3>
+<div class="sect3">
+<h4 id="_no_versioned_sql_files_found"><a class="anchor" href="#_no_versioned_sql_files_found"></a><a class="link" href="#_no_versioned_sql_files_found">7.7.1. "No versioned SQL files found"</a></h4>
+<div class="paragraph">
+<p><strong>Problem</strong>: The script can&#8217;t find <code>sql/{ext}--{version}.sql</code> files.</p>
+</div>
+<div class="paragraph">
+<p><strong>Solution</strong>: Run <code>make</code> first to generate versioned files from your base <code>sql/{ext}.sql</code> file.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_control_file_not_found"><a class="anchor" href="#_control_file_not_found"></a><a class="link" href="#_control_file_not_found">7.7.2. "Control file not found"</a></h4>
+<div class="paragraph">
+<p><strong>Problem</strong>: The script can&#8217;t find <code>{ext}.control</code> in the current directory.</p>
+</div>
+<div class="paragraph">
+<p><strong>Solution</strong>: Run <code>make pgtle</code> from your extension&#8217;s root directory (where the <code>.control</code> file is).</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_sql_file_contains_reserved_pg_tle_delimiter"><a class="anchor" href="#_sql_file_contains_reserved_pg_tle_delimiter"></a><a class="link" href="#_sql_file_contains_reserved_pg_tle_delimiter">7.7.3. "SQL file contains reserved pg_tle delimiter"</a></h4>
+<div class="paragraph">
+<p><strong>Problem</strong>: Your SQL files contain the string <code>$<em>pgtle_wrap_delimiter</em>$</code> (extremely unlikely).</p>
+</div>
+<div class="paragraph">
+<p><strong>Solution</strong>: Don&#8217;t use that dollar-quote delimiter in your code.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_extension_uses_c_code"><a class="anchor" href="#_extension_uses_c_code"></a><a class="link" href="#_extension_uses_c_code">7.7.4. Extension uses C code</a></h4>
+<div class="paragraph">
+<p><strong>Problem</strong>: Your control file has <code>module_pathname</code>, indicating C code.</p>
+</div>
+<div class="paragraph">
+<p><strong>Solution</strong>: pg_tle only supports trusted languages. You cannot use C extensions with pg_tle. The script will warn you but still generate files (which won&#8217;t work).</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+there are several untrusted languages (such as plpython), and the only tests for C.
+== Copyright
+Copyright (c) 2026 Jim Nasby &lt;<a href="mailto:Jim.Nasby@gmail.com">Jim.Nasby@gmail.com</a>&gt;
+</td>
+</tr>
+</table>
 </div>
 <div class="paragraph">
 <p>PGXNtool is released under a <a href="https://github.com/decibel/pgxntool/blob/master/LICENCE">BSD license</a>. Note that it includes <a href="https://github.com/dominictarr/JSON.sh">JSON.sh</a>, which is released under a <a href="https://github.com/decibel/pgxntool/blob/master/JSON.sh.LICENCE">MIT license</a>.</p>
@@ -793,9 +1494,11 @@ Because of this, <code>base.mk</code> will forcibly define it to be NULL if it&#
 </div>
 </div>
 </div>
+</div>
+</div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2016-11-19 15:40:59 CST
+Last updated 2026-03-26 16:45:03 -0500
 </div>
 </div>
 </body>

--- a/_.gitignore
+++ b/_.gitignore
@@ -1,11 +1,15 @@
 # Editor files
 .*.swp
 
+# Claude Code local settings
+.claude/*.local.json
+
 # Explicitly exclude META.json!
 !/META.json
 
 # Generated make files
 meta.mk
+control.mk
 
 # Compiler output
 *.o
@@ -13,14 +17,24 @@ meta.mk
 .deps/
 
 # built targets
-/sql/*--*
-!/sql/*--*--*.sql
+# Note: Version-specific files (sql/*--*.sql) are now tracked in git and should be committed
 
 # Test artifacts
 results/
 regression.diffs
 regression.out
 
+# Generated sql/ directory for test/build
+# Created by make test-build. See README.asc for details.
+test/build/sql/
+
+# Auto-generated schedule file for test/install
+# Created by make when test/install/*.sql files exist.
+test/install/schedule
+
 # Misc
 tmp/
 .DS_Store
+
+# pg_tle generated files
+/pg_tle/

--- a/base.mk
+++ b/base.mk
@@ -1,5 +1,8 @@
 PGXNTOOL_DIR := pgxntool
 
+# Ensure 'all' is the default target (not META.json which happens to be first)
+.DEFAULT_GOAL := all
+
 #
 # META.json
 #
@@ -10,12 +13,29 @@ META.json: META.in.json $(PGXNTOOL_DIR)/build_meta.sh
 #
 # meta.mk
 #
-# Buind meta.mk, which contains info from META.json, and include it
+# Build meta.mk, which contains PGXN distribution info from META.json
 PGXNTOOL_distclean += meta.mk
 meta.mk: META.json Makefile $(PGXNTOOL_DIR)/base.mk $(PGXNTOOL_DIR)/meta.mk.sh
 	@$(PGXNTOOL_DIR)/meta.mk.sh $< >$@
 
 -include meta.mk
+
+#
+# control.mk
+#
+# Build control.mk, which contains extension info from .control files
+# This is separate from meta.mk because:
+#   - META.json specifies PGXN distribution metadata
+#   - .control files specify what PostgreSQL actually uses (e.g., default_version)
+# These can differ, and PostgreSQL cares about the control file version.
+#
+# Find all control files first (needed for dependencies)
+PGXNTOOL_CONTROL_FILES := $(wildcard *.control)
+PGXNTOOL_distclean += control.mk
+control.mk: $(PGXNTOOL_CONTROL_FILES) Makefile $(PGXNTOOL_DIR)/base.mk $(PGXNTOOL_DIR)/control.mk.sh
+	@$(PGXNTOOL_DIR)/control.mk.sh $(PGXNTOOL_CONTROL_FILES) >$@
+
+-include control.mk
 
 DATA         = $(EXTENSION_VERSION_FILES) $(wildcard sql/*--*--*.sql)
 DOC_DIRS	+= doc
@@ -24,25 +44,151 @@ DOCS		+= $(foreach dir,$(DOC_DIRS),$(wildcard $(dir)/*))
 
 # Find all asciidoc targets
 ASCIIDOC ?= $(shell which asciidoctor 2>/dev/null || which asciidoc 2>/dev/null)
-ASCIIDOC_EXTS	+= adoc asciidoc
+ASCIIDOC_EXTS	+= adoc asciidoc asc
 ASCIIDOC_FILES	+= $(foreach dir,$(DOC_DIRS),$(foreach ext,$(ASCIIDOC_EXTS),$(wildcard $(dir)/*.$(ext))))
 
 PG_CONFIG   ?= pg_config
 TESTDIR		?= test
 TESTOUT		?= $(TESTDIR)
-TEST_SOURCE_FILES	+= $(wildcard $(TESTDIR)/input/*.source)
-TEST_OUT_FILES		 = $(subst input,output,$(TEST_SOURCE_FILES))
 TEST_SQL_FILES		+= $(wildcard $(TESTDIR)/sql/*.sql)
 TEST_RESULT_FILES	 = $(patsubst $(TESTDIR)/sql/%.sql,$(TESTDIR)/expected/%.out,$(TEST_SQL_FILES))
-TEST_FILES	 = $(TEST_SOURCE_FILES) $(TEST_SQL_FILES)
-REGRESS		 = $(sort $(notdir $(subst .source,,$(TEST_FILES:.sql=)))) # Sort is to get unique list
-REGRESS_OPTS = --inputdir=$(TESTDIR) --outputdir=$(TESTOUT) --load-language=plpgsql
+TEST_FILES	 = $(TEST_SQL_FILES)
+REGRESS		 = $(sort $(notdir $(TEST_FILES:.sql=)))
+REGRESS_OPTS = --inputdir=$(TESTDIR) --outputdir=$(TESTOUT) # See additional setup below
+
+#
+# OPTIONAL TEST FEATURES
+#
+# These sections configure optional test features. Each feature can be enabled/disabled
+# via a makefile variable. If not explicitly set, features auto-detect based on
+# directory existence or default behavior. The actual feature implementation is
+# located later in this file (see test-build target, schedule file generation, etc.).
+#
+
+# Helper function: normalize a yes/no variable to lowercase and validate.
+# Usage: $(call pgxntool_validate_yesno,VALUE,VARIABLE_NAME)
+# Returns the lowercase value ("yes" or "no"), or errors if invalid.
+pgxntool_validate_yesno = $(strip \
+  $(if $(filter yes no,$(shell echo "$(1)" | tr '[:upper:]' '[:lower:]')),\
+    $(shell echo "$(1)" | tr '[:upper:]' '[:lower:]'),\
+    $(error $(2) must be "yes" or "no", got "$(1)")))
+
+# ------------------------------------------------------------------------------
+# test-build: Sanity check extension files before running full test suite
+# ------------------------------------------------------------------------------
+# Purpose: Validates that extension SQL files are syntactically correct by running
+#          files from test/build/ through pg_regress. This provides better error
+#          messages than CREATE EXTENSION failures.
+#
+# Variable: PGXNTOOL_ENABLE_TEST_BUILD
+#   - Can be set manually in Makefile or command line
+#   - Allowed values: "yes" or "no" (case-insensitive)
+#   - If not set: Auto-detects based on existence of test/build/*.sql files
+#   - Set to "yes" explicitly to get an error if test/build/ has no SQL files
+#     (useful to catch accidental deletion of test/build/ contents)
+#   - Set to "no" explicitly to disable even when test/build/ has SQL files
+#
+# Implementation: See test-build target definition (search for "test-build:" in this file)
+#
+TEST_BUILD_SQL_FILES = $(wildcard $(TESTDIR)/build/*.sql)
+TEST_BUILD_FILES = $(TEST_BUILD_SQL_FILES)
+ifdef PGXNTOOL_ENABLE_TEST_BUILD
+  PGXNTOOL_ENABLE_TEST_BUILD := $(call pgxntool_validate_yesno,$(PGXNTOOL_ENABLE_TEST_BUILD),PGXNTOOL_ENABLE_TEST_BUILD)
+else
+  # Auto-detect: enable if test/build/ directory has SQL files
+  ifneq ($(strip $(TEST_BUILD_FILES)),)
+    PGXNTOOL_ENABLE_TEST_BUILD = yes
+  else
+    PGXNTOOL_ENABLE_TEST_BUILD = no
+  endif
+endif
+
+# ------------------------------------------------------------------------------
+# test/install: Run setup files before all tests in the same pg_regress session
+# ------------------------------------------------------------------------------
+# Purpose: Runs files from test/install/ before all test/sql/ files within a
+#          SINGLE pg_regress invocation via schedule files. This ensures that
+#          state created by install files (tables, extensions, etc.) persists
+#          into the main test suite.
+#
+# Variable: PGXNTOOL_ENABLE_TEST_INSTALL
+#   - Can be set manually in Makefile or command line
+#   - Allowed values: "yes" or "no" (case-insensitive)
+#   - If not set: Auto-detects based on existence of test/install/*.sql files
+#   - Set to "yes" explicitly to get an error if test/install/ has no SQL files
+#     (useful to catch accidental deletion of test/install/ contents)
+#   - Set to "no" explicitly to disable even when test/install/ has SQL files
+#
+# Directory layout (follows ~/code/extensions/archive/ pattern):
+#   test/install/*.sql      - Install SQL files
+#   test/install/*.out      - Expected output (lives alongside .sql files)
+#   test/install/schedule   - Auto-generated schedule file
+#   test/sql/schedule       - Auto-generated schedule file for regular tests
+#
+# The schedule files use relative paths (../install/testname) so pg_regress
+# resolves install files from their original location without copying.
+#
+# NOTE: The variable normalization pattern below (ifdef/NORM/error/override) is
+# identical to test-build and verify-results. Refactoring options:
+#   1. A $(call normalize_bool_var,VAR,DEFAULT) Make function
+#   2. A small include fragment (e.g. pgxntool/mk/bool-var.mk)
+# Either approach would eliminate the ~10-line block repeated for each feature.
+TEST_INSTALL_SQL_FILES = $(wildcard $(TESTDIR)/install/*.sql)
+ifdef PGXNTOOL_ENABLE_TEST_INSTALL
+  PGXNTOOL_ENABLE_TEST_INSTALL := $(call pgxntool_validate_yesno,$(PGXNTOOL_ENABLE_TEST_INSTALL),PGXNTOOL_ENABLE_TEST_INSTALL)
+else
+  # Auto-detect: enable if test/install/ directory has SQL files
+  ifneq ($(strip $(TEST_INSTALL_SQL_FILES)),)
+    PGXNTOOL_ENABLE_TEST_INSTALL = yes
+  else
+    PGXNTOOL_ENABLE_TEST_INSTALL = no
+  endif
+endif
+
+# ------------------------------------------------------------------------------
+# verify-results: Safeguard for make results
+# ------------------------------------------------------------------------------
+# Purpose: Prevents accidentally running 'make results' when tests are failing.
+#
+# Variable: PGXNTOOL_ENABLE_VERIFY_RESULTS
+#   - Can be set manually in Makefile or command line
+#   - Allowed values: "yes" or "no" (case-insensitive)
+#   - Setting to empty on the command line (e.g. PGXNTOOL_ENABLE_VERIFY_RESULTS=) also disables the feature
+#   - If not set: Defaults to "yes" (enabled by default for all pgxntool projects)
+#   - Usage: Controls whether verify-results target exists and blocks make results
+#
+# Variable: PGXNTOOL_VERIFY_RESULTS_MODE
+#   - Controls how verify-results detects test failures
+#   - "pgtap" (default): scans test/results/*.out for "not ok" lines and plan
+#     mismatches (TAP failures). Also checks regression.diffs as a fallback.
+#     Use this mode when your test suite uses pgTap.
+#   - "diffs": checks only for regression.diffs existence (classic pg_regress behavior)
+#     Use this mode when your tests use plain SQL expected-output comparison only.
+#
+# Implementation: See verify-results target definition and results target modification
+#                 (search for "verify-results" and "results:" in this file)
+#
+ifdef PGXNTOOL_ENABLE_VERIFY_RESULTS
+  override PGXNTOOL_ENABLE_VERIFY_RESULTS := $(call pgxntool_validate_yesno,$(PGXNTOOL_ENABLE_VERIFY_RESULTS),PGXNTOOL_ENABLE_VERIFY_RESULTS)
+else
+  # Default to yes (enabled by default for all pgxntool projects)
+  PGXNTOOL_ENABLE_VERIFY_RESULTS = yes
+endif
+
+# Default mode: pgtap (scans results/*.out for TAP failures)
+PGXNTOOL_VERIFY_RESULTS_MODE ?= pgtap
+
+# Generate unique database name for tests to prevent conflicts across projects
+# Uses project name + first 5 chars of md5 hash of current directory
+# This prevents multiple test runs in different directories from clobbering each other
+REGRESS_DBHASH := $(shell echo $(CURDIR) | (md5 2>/dev/null || md5sum) | cut -c1-5)
+REGRESS_DBNAME := $(or $(PGXN),regression)_$(REGRESS_DBHASH)
 MODULES      = $(patsubst %.c,%,$(wildcard src/*.c))
 ifeq ($(strip $(MODULES)),)
 MODULES =# Set to NUL so PGXS doesn't puke
 endif
 
-EXTRA_CLEAN  = $(wildcard ../$(PGXN)-*.zip) $(EXTENSION_VERSION_FILES)
+EXTRA_CLEAN  = $(wildcard ../$(PGXN)-*.zip) pg_tle/
 
 # Get Postgres version, as well as major (9.4, etc) version.
 # NOTE! In at least some versions, PGXS defines VERSION, so we intentionally don't use that variable
@@ -57,8 +203,39 @@ GE91		 = $(call test, $(MAJORVER), -ge, 91)
 
 ifeq ($(GE91),yes)
 all: $(EXTENSION_VERSION_FILES)
+endif
 
-#DATA = $(wildcard sql/*--*.sql)
+ifeq ($(call test, $(MAJORVER), -lt, 130), yes)
+REGRESS_OPTS += --load-language=plpgsql
+endif
+
+#
+# test/install: Schedule-based approach
+#
+# When enabled, generates a schedule file listing install files, and adds it
+# to REGRESS_OPTS. pg_regress processes --schedule tests before command-line
+# test names, so install files run first in the SAME pg_regress invocation.
+# This ensures state created by install files persists into the main test suite.
+#
+# The schedule uses relative paths (../install/testname) so pg_regress finds
+# install files in their original location without copying.
+#
+ifeq ($(PGXNTOOL_ENABLE_TEST_INSTALL),yes)
+PGXNTOOL_INSTALL_SCHEDULE = $(TESTDIR)/install/schedule
+EXTRA_CLEAN += $(PGXNTOOL_INSTALL_SCHEDULE)
+
+# Add install schedule; REGRESS stays as-is (regular tests run after schedule)
+REGRESS_OPTS += --schedule=$(PGXNTOOL_INSTALL_SCHEDULE)
+
+# Always regenerate schedule file to catch added/removed files
+.PHONY: $(PGXNTOOL_INSTALL_SCHEDULE)
+$(PGXNTOOL_INSTALL_SCHEDULE):
+	@echo "# Auto-generated - DO NOT EDIT" > $@
+	@for f in $(notdir $(basename $(TEST_INSTALL_SQL_FILES))); do \
+		echo "test: ../install/$$f" >> $@; \
+	done
+
+installcheck: $(PGXNTOOL_INSTALL_SCHEDULE)
 endif
 
 PGXS := $(shell $(PG_CONFIG) --pgxs)
@@ -68,7 +245,7 @@ DATA += $(wildcard *.control)
 
 # Don't have installcheck bomb on error
 .IGNORE: installcheck
-installcheck: $(TEST_RESULT_FILES) $(TEST_OUT_FILES) $(TEST_SQL_FILES) $(TEST_SOURCE_FILES)
+installcheck: $(TEST_RESULT_FILES) $(TEST_SQL_FILES) | $(TESTDIR)/sql/ $(TESTDIR)/expected/ $(TESTOUT)/results/
 
 #
 # TEST SUPPORT
@@ -82,30 +259,130 @@ installcheck: $(TEST_RESULT_FILES) $(TEST_OUT_FILES) $(TEST_SQL_FILES) $(TEST_SO
 # watch-make if you're generating intermediate files. If tests end up needing
 # clean it's an indication of a missing dependency anyway.
 .PHONY: test
-test: testdeps install installcheck
+# Build test dependencies list based on enabled features
+TEST_DEPS = testdeps
+ifeq ($(PGXNTOOL_ENABLE_TEST_BUILD),yes)
+TEST_DEPS += test-build
+endif
+TEST_DEPS += install installcheck
+test: $(TEST_DEPS)
 	@if [ -r $(TESTOUT)/regression.diffs ]; then cat $(TESTOUT)/regression.diffs; fi
 
-# make results: runs `make test` and copy all result files to expected
+#
+# verify-results: Safeguard for make results
+#
+# Checks if tests are passing before allowing make results to proceed
+ifeq ($(PGXNTOOL_ENABLE_VERIFY_RESULTS),yes)
+.PHONY: verify-results
+ifeq ($(PGXNTOOL_VERIFY_RESULTS_MODE),pgtap)
+verify-results:
+	@$(PGXNTOOL_DIR)/verify-results-pgtap.sh $(TESTOUT)
+else
+verify-results:
+	@if [ -r $(TESTOUT)/regression.diffs ]; then \
+		echo "ERROR: Tests are failing. Cannot run 'make results'."; \
+		echo "Fix test failures first, then run 'make results'."; \
+		echo ""; \
+		echo "See $(TESTOUT)/regression.diffs for details:"; \
+		cat $(TESTOUT)/regression.diffs; \
+		exit 1; \
+	fi
+endif
+endif
+
+# make results: runs `make test` and copies all result files to expected.
 # DO NOT RUN THIS UNLESS YOU'RE CERTAIN ALL YOUR TESTS ARE PASSING!
 .PHONY: results
+ifeq ($(PGXNTOOL_ENABLE_VERIFY_RESULTS),yes)
+results: verify-results test
+else
 results: test
-	rsync -rlpgovP $(TESTOUT)/results/ $(TESTDIR)/expected
+endif
+	@mkdir -p $(TESTDIR)/expected
+	@for f in $(TESTOUT)/results/*.out; do \
+		[ -f "$$f" ] || continue; \
+		cp "$$f" $(TESTDIR)/expected/$$(basename "$$f"); \
+	done
 
 # testdeps is a generic dependency target that you can add targets to
 .PHONY: testdeps
 testdeps: pgtap
 
+#
+# pg_tle support - Generate pg_tle registration SQL
+#
+
+# PGXNTOOL_CONTROL_FILES is defined above (for control.mk dependencies)
+PGXNTOOL_EXTENSIONS = $(basename $(PGXNTOOL_CONTROL_FILES))
+
+# Main target
+# Depend on 'all' to ensure versioned SQL files are generated first
+# Depend on control.mk (which defines EXTENSION_VERSION_FILES)
+# Depend on control files explicitly so changes trigger rebuilds
+# Generates all supported pg_tle versions for each extension
+.PHONY: pgtle
+pgtle: all control.mk $(PGXNTOOL_CONTROL_FILES)
+	@$(foreach ext,$(PGXNTOOL_EXTENSIONS),\
+		$(PGXNTOOL_DIR)/pgtle.sh --extension $(ext);)
+
+#
+# pg_tle installation support
+#
+
+# Check if pg_tle is installed and report version
+# Only reports version if CREATE EXTENSION pg_tle has been run
+# Errors if pg_tle extension is not installed
+# Uses pgtle.sh to get version (avoids code duplication)
+.PHONY: check-pgtle
+check-pgtle:
+	@echo "Checking pg_tle installation..."
+	@PGTLE_VERSION=$$($(PGXNTOOL_DIR)/pgtle.sh --get-version 2>/dev/null); \
+	if [ -n "$$PGTLE_VERSION" ]; then \
+		echo "pg_tle extension version: $$PGTLE_VERSION"; \
+		exit 0; \
+	fi; \
+	echo "ERROR: pg_tle extension is not installed" >&2; \
+	echo "       Run 'CREATE EXTENSION pg_tle;' first" >&2; \
+	exit 1
+
+# Run pg_tle registration SQL files
+# Requires pg_tle extension to be installed (checked via check-pgtle)
+# Uses pgtle.sh to determine which version range directory to use
+# Assumes PG* environment variables are configured
+.PHONY: run-pgtle
+run-pgtle: pgtle
+	@$(PGXNTOOL_DIR)/pgtle.sh --run
+
 # These targets ensure all the relevant directories exist
-$(TESTDIR)/sql:
+$(TESTDIR)/sql $(TESTDIR)/expected/ $(TESTOUT)/results/:
 	@mkdir -p $@
-$(TESTDIR)/expected/:
-	@mkdir -p $@
+# pg_regress aborts with "could not open file" if an expected output file is
+# missing, so create empty placeholders for any test that lacks one.
 $(TEST_RESULT_FILES): | $(TESTDIR)/expected/
+	@# Create empty expected file so pg_regress doesn't abort with "file not found".
+	@# pg_regress requires an expected/*.out file to exist for each test; without it
+	@# it stops immediately rather than running the test and showing the diff.
 	@touch $@
-$(TESTDIR)/output/:
-	@mkdir -p $@
-$(TEST_OUT_FILES): | $(TESTDIR)/output/ $(TESTDIR)/expected/ $(TESTDIR)/sql/
-	@touch $@
+
+#
+# test-build: Sanity check extension files in test/build/
+#
+# The sql/ subdirectory is generated - files are synced from test/build/*.sql.
+# This directory should be in .gitignore and is cleaned by make clean.
+#
+ifeq ($(PGXNTOOL_ENABLE_TEST_BUILD),yes)
+TEST_BUILD_SQL_DIR = $(TESTDIR)/build/sql
+TEST_BUILD_REGRESS = $(sort $(notdir $(basename $(TEST_BUILD_SQL_FILES))))
+.PHONY: test-build
+test-build: install
+	@$(PGXNTOOL_DIR)/run-test-build.sh $(TESTDIR)
+	$(MAKE) -C . REGRESS="$(TEST_BUILD_REGRESS)" REGRESS_OPTS="--inputdir=$(TESTDIR)/build --outputdir=$(TESTDIR)/build" installcheck
+	@if [ -r $(TESTDIR)/build/regression.diffs ]; then \
+		echo "test-build failed - see $(TESTDIR)/build/regression.diffs"; \
+		cat $(TESTDIR)/build/regression.diffs; \
+		exit 1; \
+	fi
+endif
 
 
 #
@@ -135,8 +412,9 @@ dist: html
 # But don't add it as an install or test dependency unless we do have asciidoc
 ifneq (,$(strip $(ASCIIDOC)))
 
-# Need to do this so install & co will pick up ALL targets. Unfortunately this can result in some duplication.
-DOCS += $(ASCIIDOC_HTML)
+# Add HTML to DOCS for install, deduplicating against any HTML already picked
+# up by the wildcard (e.g. pre-built HTML committed to the repo).
+DOCS := $(sort $(filter-out $(ASCIIDOC_HTML),$(DOCS)) $(ASCIIDOC_HTML))
 
 # Also need to add html as a dep to all (which will get picked up by install & installcheck
 all: html
@@ -153,14 +431,23 @@ docclean:
 #
 rmtag:
 	git fetch origin # Update our remotes
-	@test -z "$$(git branch --list $(PGXNVERSION))" || git branch -d $(PGXNVERSION)
-	@test -z "$$(git branch --list -r origin/$(PGXNVERSION))" || git push --delete origin $(PGXNVERSION)
+	@test -z "$$(git tag --list $(PGXNVERSION))" || git tag -d $(PGXNVERSION)
+	@test -z "$$(git ls-remote --tags origin $(PGXNVERSION) | grep -v '{}')" || git push --delete origin $(PGXNVERSION)
 
-# TODO: Don't puke if tag already exists *and is the same*
 tag:
 	@test -z "$$(git status --porcelain)" || (echo 'Untracked changes!'; echo; git status; exit 1)
-	git branch $(PGXNVERSION)
-	git push --set-upstream origin $(PGXNVERSION)
+	@# Skip if tag already exists and points to HEAD
+	@if git rev-parse $(PGXNVERSION) >/dev/null 2>&1; then \
+		if [ "$$(git rev-parse $(PGXNVERSION))" = "$$(git rev-parse HEAD)" ]; then \
+			echo "Tag $(PGXNVERSION) already exists at HEAD, skipping"; \
+		else \
+			echo "ERROR: Tag $(PGXNVERSION) exists but points to different commit" >&2; \
+			exit 1; \
+		fi; \
+	else \
+		git tag $(PGXNVERSION); \
+	fi
+	git push origin $(PGXNVERSION)
 
 .PHONY: forcetag
 forcetag: rmtag tag
@@ -169,6 +456,13 @@ forcetag: rmtag tag
 dist: tag dist-only
 
 dist-only:
+	@# Check if .gitattributes exists but isn't committed
+	@if [ -f .gitattributes ] && ! git ls-files --error-unmatch .gitattributes >/dev/null 2>&1; then \
+		echo "ERROR: .gitattributes exists but is not committed to git." >&2; \
+		echo "       git archive only respects export-ignore for committed files." >&2; \
+		echo "       Please commit .gitattributes for export-ignore to take effect." >&2; \
+		exit 1; \
+	fi
 	git archive --prefix=$(PGXN)-$(PGXNVERSION)/ -o ../$(PGXN)-$(PGXNVERSION).zip $(PGXNVERSION)
 
 .PHONY: forcedist
@@ -190,18 +484,29 @@ print-%	: ; $(info $* is $(flavor $*) variable set to "$($*)") @true
 #
 # This is setup to allow any number of pull targets by defining special
 # variables. pgxntool-sync-release is an example of this.
-.PHONY: pgxn-sync-%
+#
+# After the subtree pull, we run update-setup-files.sh to handle files that
+# were initially copied by setup.sh (like .gitignore). This script does a
+# 3-way merge if both you and pgxntool changed the file.
+.PHONY: pgxntool-sync-%
 pgxntool-sync-%:
-	git subtree pull -P pgxntool --squash -m "Pull pgxntool from $($@)" $($@)
+	@old_commit=$$(git log -1 --format=%H -- pgxntool/) && \
+	git subtree pull -P pgxntool --squash -m "Pull pgxntool from $($@)" $($@) && \
+	pgxntool/update-setup-files.sh "$$old_commit"
 pgxntool-sync: pgxntool-sync-release
 
 # DANGER! Use these with caution. They may add extra crap to your history and
 # could make resolving merges difficult!
 pgxntool-sync-release	:= git@github.com:decibel/pgxntool.git release
 pgxntool-sync-stable	:= git@github.com:decibel/pgxntool.git stable
+pgxntool-sync-master	:= git@github.com:decibel/pgxntool.git master
 pgxntool-sync-local		:= ../pgxntool release # Not the same as PGXNTOOL_DIR!
 pgxntool-sync-local-stable	:= ../pgxntool stable # Not the same as PGXNTOOL_DIR!
+pgxntool-sync-local-master	:= ../pgxntool master # Not the same as PGXNTOOL_DIR!
 
+# PGXS doesn't provide any special support for distclean (it just depends on
+# clean), so we roll our own. Files that should only be removed by distclean
+# (not clean) are added to PGXNTOOL_distclean near their build rules above.
 distclean:
 	rm -f $(PGXNTOOL_distclean)
 
@@ -212,6 +517,22 @@ DOCS =# Set to NUL so PGXS doesn't puke
 endif
 
 include $(PGXS)
+
+# Override CONTRIB_TESTDB (set unconditionally by PGXS) with our unique database
+# name. This must be after include $(PGXS) because PGXS uses = (not ?=).
+# PGXS appends --dbname=$(CONTRIB_TESTDB) to REGRESS_OPTS, so overriding
+# CONTRIB_TESTDB is the correct way to control the database name — adding our
+# own --dbname would result in two --dbname flags passed to pg_regress.
+CONTRIB_TESTDB = $(REGRESS_DBNAME)
+
+# Clean generated sql/ directory for test-build
+ifeq ($(PGXNTOOL_ENABLE_TEST_BUILD),yes)
+.PHONY: clean-test-build
+clean-test-build:
+	rm -rf $(TEST_BUILD_SQL_DIR)
+clean: clean-test-build
+endif
+
 #
 # pgtap
 #

--- a/build_meta.sh
+++ b/build_meta.sh
@@ -1,16 +1,28 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# Build META.json from META.in.json template
+#
+# WHY META.in.json EXISTS:
+# META.in.json serves as a template that:
+# 1. Shows all possible PGXN metadata fields (both required and optional) with comments
+# 2. Can have empty placeholder fields like "key": "" or "key": [ "", "" ]
+# 3. Users edit this to fill in their extension's metadata
+#
+# WHY WE GENERATE META.json:
+# The reason we generate META.json from a template is to eliminate empty fields that
+# are optional; PGXN.org gets upset about them. In the future it's possible we'll do
+# more here (for example, if we added more info to the template we could use it to
+# generate control files).
+#
+# WHY WE COMMIT META.json:
+# PGXN.org requires META.json to be present in submitted distributions. We choose
+# to commit it to git instead of manually adding it to distributions for simplicity
+# (and since it generally only changes once for each new version).
 
 set -e
 
-error () {
-    echo $@ >&2
-}
-die () {
-    return=$1
-    shift
-    error $@
-    exit $return
-}
+BASEDIR=$(dirname "$0")
+source "$BASEDIR/lib.sh"
 
 [ $# -eq 2 ] || die 2 Invalid number of arguments $#
 

--- a/control.mk.sh
+++ b/control.mk.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# control.mk.sh - Generate Makefile rules from PostgreSQL extension control files
+#
+# This script parses .control files to extract extension metadata (particularly
+# default_version) and generates Make variables and rules for building versioned
+# SQL files.
+#
+# Usage: control.mk.sh <control_file> [<control_file> ...]
+#
+# Output (to stdout, meant to be redirected to control.mk):
+#   EXTENSIONS += <ext_name>
+#   EXTENSION_SQL_FILES += sql/<ext_name>.sql
+#   EXTENSION_<ext_name>_VERSION := <version>
+#   EXTENSION_<ext_name>_VERSION_FILE = sql/<ext_name>--<version>.sql
+#   EXTENSION_VERSION_FILES += $(EXTENSION_<ext_name>_VERSION_FILE)
+#   <rules for generating versioned SQL files>
+#
+# Why control files instead of META.json?
+#   META.json's "provides" section specifies versions for PGXN distribution metadata.
+#   But PostgreSQL uses the control file's default_version to determine which
+#   versioned SQL file to load. These can differ (e.g., PGXN distribution version
+#   might be updated independently of extension version). Using the control file
+#   ensures the generated SQL files match what PostgreSQL expects.
+
+set -o errexit -o errtrace -o pipefail
+
+BASEDIR=$(dirname "$0")
+source "$BASEDIR/lib.sh"
+
+# Extract default_version from a PostgreSQL extension control file
+# Usage: get_control_default_version <control_file>
+# Errors if:
+#   - Control file doesn't exist
+#   - default_version is not specified (pgxntool requires it)
+#   - Multiple default_version lines exist
+get_control_default_version() {
+  local control_file="$1"
+
+  if [ ! -f "$control_file" ]; then
+    die 2 "Control file '$control_file' not found"
+  fi
+
+  # Count default_version lines
+  local count
+  count=$(grep -cE "^[[:space:]]*default_version[[:space:]]*=" "$control_file" 2>/dev/null) || count=0
+
+  if [ "$count" -eq 0 ]; then
+    die 2 "default_version not specified in '$control_file'. PostgreSQL allows extensions without a default_version, but pgxntool requires it to generate versioned SQL files."
+  fi
+
+  if [ "$count" -gt 1 ]; then
+    die 2 "Multiple default_version lines found in '$control_file'. Control files must have exactly one default_version."
+  fi
+
+  # Extract the version value
+  # Handles: default_version = '1.0', default_version = "1.0", trailing comments
+  local version=$(grep -E "^[[:space:]]*default_version[[:space:]]*=" "$control_file" | \
+    sed -e "s/^[^=]*=[[:space:]]*//" \
+        -e "s/[[:space:]]*#.*//" \
+        -e "s/^['\"]//;s/['\"]$//" )
+
+  if [ -z "$version" ]; then
+    die 2 "Could not parse default_version value from '$control_file'"
+  fi
+
+  echo "$version"
+}
+
+# Main: process each control file passed as argument
+if [ $# -eq 0 ]; then
+  die 1 "Usage: control.mk.sh <control_file> [<control_file> ...]"
+fi
+
+for control_file in "$@"; do
+  ext=$(basename "$control_file" .control)
+  version=$(get_control_default_version "$control_file")
+
+  echo "EXTENSIONS += $ext"
+  echo "EXTENSION_SQL_FILES += sql/${ext}.sql"
+  echo "EXTENSION_${ext}_VERSION := ${version}"
+  echo "EXTENSION_${ext}_VERSION_FILE	= sql/${ext}--\$(EXTENSION_${ext}_VERSION).sql"
+  echo "EXTENSION_VERSION_FILES		+= \$(EXTENSION_${ext}_VERSION_FILE)"
+  echo "\$(EXTENSION_${ext}_VERSION_FILE): sql/${ext}.sql ${control_file}"
+  echo "	@echo '/* DO NOT EDIT - AUTO-GENERATED FILE */' > \$(EXTENSION_${ext}_VERSION_FILE)"
+  echo "	@cat sql/${ext}.sql >> \$(EXTENSION_${ext}_VERSION_FILE)"
+  echo
+done
+
+# vi: expandtab ts=2 sw=2

--- a/lib.sh
+++ b/lib.sh
@@ -1,0 +1,78 @@
+# lib.sh - Common utility functions for pgxntool scripts
+#
+# This file is meant to be sourced by other scripts, not executed directly.
+# Usage: source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# =============================================================================
+# SETUP FILES CONFIGURATION
+# =============================================================================
+# Files copied by setup.sh and tracked by update-setup-files.sh for sync updates.
+# Format: "source_in_pgxntool:destination_in_project"
+# =============================================================================
+SETUP_FILES=(
+    "_.gitignore:.gitignore"
+    "test/deps.sql:test/deps.sql"
+)
+
+# Symlinks created by setup.sh and verified by update-setup-files.sh
+# Format: "destination:target"
+SETUP_SYMLINKS=(
+    "test/pgxntool:../pgxntool/test/pgxntool"
+)
+
+# Error function - outputs to stderr but doesn't exit
+# Usage: error "message"
+error() {
+    echo "ERROR: $*" >&2
+}
+
+# Die function - outputs error message and exits with specified code
+# Usage: die EXIT_CODE "message"
+die() {
+    local exit_code=$1
+    shift
+    error "$@"
+    exit $exit_code
+}
+
+# Returns true if an array isn't empty.
+#
+#   array_not_empty "${#errors[@]}"
+#
+# BUT WHY ON EARTH DO THIS??
+#
+# This wraps a one-liner intentionally. The function forces any reader
+# (human or AI agent) to navigate here and read this comment before
+# "simplifying" the call site. Without it, the natural next step is to
+# inline the expression — and the natural inline form breaks bash 3.2.
+#
+# On bash 3.2 (Mac OS default), when using `set -u`, expanding "${arr[@]}"
+# on an empty array triggers "unbound variable" even when the array was
+# explicitly initialized with arr=().
+#
+# The comment inside the function body exists to catch any agent or human who
+# navigates to the function without reading this comment first.
+array_not_empty() {
+    # DO NOT EDIT THIS FUNCTION! DO NOT REMOVE THIS COMMENT! (see main function comment)
+    [ "${1:-0}" -gt 0 ]
+}
+
+# Debug function
+# Usage: debug LEVEL "message"
+# Outputs message to stderr if DEBUG >= LEVEL
+# Debug levels use multiples of 10 (10, 20, 30, 40, etc.) to allow for easy expansion
+#   - 10: Critical errors, important warnings
+#   - 20: Warnings, significant state changes
+#   - 30: General debugging, function entry/exit, array operations
+#   - 40: Verbose details, loop iterations
+#   - 50+: Maximum verbosity
+# Enable with: DEBUG=30 scriptname.sh
+debug() {
+    local level=$1
+    shift
+    local message="$*"
+
+    if [ "${DEBUG:-0}" -ge "$level" ]; then
+        echo "DEBUG[$level]: $message" >&2
+    fi
+}

--- a/meta.mk.sh
+++ b/meta.mk.sh
@@ -1,25 +1,38 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
+#
+# meta.mk.sh - Generate Makefile variables from META.json
+#
+# This script parses META.json (PGXN distribution metadata) and generates
+# Make variables for the distribution name and version.
+#
+# Usage: meta.mk.sh <META.json>
+#
+# Output (to stdout, meant to be redirected to meta.mk):
+#   PGXN := <distribution_name>
+#   PGXNVERSION := <distribution_version>
+#
+# Note: Extension-specific variables (like EXTENSION_*_VERSION) are generated
+# by control.mk.sh from .control files, not from META.json. This is because
+# META.json specifies PGXN distribution metadata, while .control files specify
+# what PostgreSQL actually uses.
 
 set -o errexit -o errtrace -o pipefail
-trap 'echo "Error on line ${LINENO}" >&2' ERR
 
-META=$1
-BASEDIR=`dirname $0`
+BASEDIR=$(dirname "$0")
+source "$BASEDIR/lib.sh"
+
 JSON_SH=$BASEDIR/JSON.sh
 
-error () {
-  echo $@ >&2
-}
 trap 'error "Error on line ${LINENO}"' ERR
 
-die () {
-  local retval=$1
-  shift
-  error $@
-  exit $retval
-}
+META=$1
+if [ -z "$META" ]; then
+  die 1 "Usage: meta.mk.sh <META.json>"
+fi
 
-REQUIRED='abstract maintainer license provides name version'
+if [ ! -f "$META" ]; then
+  die 2 "META.json file '$META' not found"
+fi
 
 #function to get value of specified key
 #returns empty string if not found
@@ -27,7 +40,7 @@ REQUIRED='abstract maintainer license provides name version'
 #usage: VAR=$(getkey foo.bar) #get value of "bar" contained within "foo"
 #       VAR=$(getkey foo[4].bar) #get value of "bar" contained in the array "foo" on position 4
 #       VAR=$(getkey [4].foo) #get value of "foo" contained in the root unnamed array on position 4
-function _getkey {
+_getkey() {
     #reformat key string (parameter) to what JSON.sh uses
     KEYSTRING=$(sed -e 's/\[/\"\,/g' -e 's/^\"\,/\[/g' -e 's/\]\./\,\"/g' -e 's/\./\"\,\"/g' -e '/^\[/! s/^/\[\"/g' -e '/\]$/! s/$/\"\]/g' <<< "$@")
     #extract the key value
@@ -37,60 +50,21 @@ function _getkey {
     FOUT="${FOUT%\"*}"
     echo "$FOUT"
 }
-function getkeys {
-    KEYSTRING=$(sed -e 's/\[/\"\,/g' -e 's/^\"\,/\[/g' -e 's/\]\./\,\"/g' -e 's/\./\"\,\"/g' -e '/^\[/! s/^/\[\"/g' -e '/\",\"$/! s/$/\",\"/g' <<< "$@")
-    #extract the key value
-    FOUT=$(grep -F "$KEYSTRING" <<< "$JSON_PARSED")
-    FOUT="${FOUT%$'\t'*}"
-    echo "$FOUT"
-}
 
-#function returning length of array
-#returns zero if key in parameter does not exist or is not an array
-#usage: VAR=$(getarrlen foo.bar) #get length of array "bar" contained within "foo"
-#       VAR=$(getarrlen) #get length of the root unnamed array
-#       VAR=$(getarrlen [2].foo.bar) #get length of array "bar" contained within "foo", which is stored in the root unnamed array on position 2
-function getarrlen {
-    #reformat key string (parameter) to what JSON.sh uses
-    KEYSTRING=$(gsed -e '/^\[/! s/\[/\"\,/g' -e 's/\]\./\,\"/g' -e 's/\./\"\,\"/g' -e '/^$/! {/^\[/! s/^/\[\"/g}' -e '/^$/! s/$/\"\,/g' -e 's/\[/\\\[/g' -e 's/\]/\\\]/g' -e 's/\,/\\\,/g' -e '/^$/ s/^/\\\[/g' <<< "$@")
-    #extract the key array length - get last index
-    LEN=$(grep -o "${KEYSTRING}[0-9]*" <<< "$JSON_PARSED" | tail -n -1 | grep -o "[0-9]*$")
-    #increment to get length, if empty => zero
-    if [ -n "$LEN" ]; then
-        LEN=$(($LEN+1))
-    else
-        LEN="0"
-    fi
-    echo "$LEN"
-}
-
-JSON_PARSED=$(cat $META | $JSON_SH -l)
-
-function getkey {
+getkey() {
   out=$(_getkey "$@")
   [ -n "$out" ] || die 2 "key $@ not found in $META"
   echo $out
 }
 
-# Handle meta-spec specially
-spec_version=`getkey meta-spec.version`
-[ "$spec_version" == "1.0.0" ] || die 2 "Unknown meta-spec/version: $PGXN_meta-spec_version"
+JSON_PARSED=$(cat "$META" | $JSON_SH -l)
 
+# Validate meta-spec version
+spec_version=$(getkey meta-spec.version)
+[ "$spec_version" == "1.0.0" ] || die 2 "Unknown meta-spec/version: $spec_version"
+
+# Output distribution name and version
 echo "PGXN := $(getkey name)"
 echo "PGXNVERSION := $(getkey version)"
-echo
-
-provides=$(getkeys provides | sed -e 's/\["provides","//' -e 's/",".*//' | uniq)
-for ext in $provides; do
-  version=$(getkey provides.${ext}.version)
-  [ -n "$version" ] || die 2 "provides/${ext} does not specify a version number"
-  echo "EXTENSIONS += $ext"
-  echo "EXTENSION_SQL_FILES += sql/${ext}.sql"
-  echo "EXTENSION_${ext}_VERSION := ${version}"
-  echo "EXTENSION_${ext}_VERSION_FILE	= sql/${ext}--\$(EXTENSION_${ext}_VERSION).sql"
-  echo "EXTENSION_VERSION_FILES		+= \$(EXTENSION_${ext}_VERSION_FILE)"
-  echo "\$(EXTENSION_${ext}_VERSION_FILE): sql/${ext}.sql META.json meta.mk"
-  echo '	cp $< $@'
-done
 
 # vi: expandtab ts=2 sw=2

--- a/pgtle.sh
+++ b/pgtle.sh
@@ -1,0 +1,850 @@
+#!/usr/bin/env bash
+#
+# pgtle.sh - Generate pg_tle registration SQL for PostgreSQL extensions
+#
+# Part of pgxntool: https://github.com/decibel/pgxntool
+#
+# SYNOPSIS
+#   pgtle.sh --extension EXTNAME [--pgtle-version VERSION]
+#   pgtle.sh --get-dir VERSION
+#   pgtle.sh --get-version
+#   pgtle.sh --run
+#
+# DESCRIPTION
+#   Generates pg_tle (Trusted Language Extensions) registration SQL from
+#   a pgxntool-based PostgreSQL extension. Reads the extension's .control
+#   file and SQL files, wrapping them for pg_tle deployment in managed
+#   environments like AWS RDS and Aurora.
+#
+#   pg_tle enables extension installation without filesystem access by
+#   storing extension code in database tables. This script converts
+#   traditional PostgreSQL extensions into pg_tle-compatible SQL.
+#
+# OPTIONS
+#   --extension NAME
+#       Extension name (required). Must match a .control file basename
+#       in the current directory.
+#
+#   --pgtle-version VERSION
+#       Generate for specific pg_tle version only (optional).
+#       Format: 1.0.0-1.4.0, 1.4.0-1.5.0, or 1.5.0+
+#       Default: Generate all supported versions
+#
+#   --get-dir VERSION
+#       Returns the directory path for the given pg_tle version.
+#       Format: VERSION is a version string like "1.5.2"
+#       Output: Directory path like "pg_tle/1.5.0+", "pg_tle/1.4.0-1.5.0", or "pg_tle/1.0.0-1.4.0"
+#       This option is used by make to determine which directory to use
+#
+#   --get-version
+#       Returns the installed pg_tle version from the database.
+#       Output: Version string like "1.5.2" or empty if not installed
+#       Exit status: 0 if pg_tle is installed, 1 if not installed
+#
+#   --run
+#       Runs the generated pg_tle registration SQL files. This option:
+#       - Detects the installed pg_tle version from the database
+#       - Determines the appropriate directory using --get-dir logic
+#       - Executes all SQL files in that directory via psql
+#       - Assumes PG* environment variables are configured for psql
+#
+# VERSION NOTATION
+#   X.Y.Z+       Works on pg_tle >= X.Y.Z
+#   X.Y.Z-A.B.C  Works on pg_tle >= X.Y.Z and < A.B.C
+#
+#   Note the boundary conditions:
+#     1.5.0+       means >= 1.5.0 (includes 1.5.0)
+#     1.4.0-1.5.0  means >= 1.4.0 and < 1.5.0 (excludes 1.5.0)
+#     1.0.0-1.4.0  means >= 1.0.0 and < 1.4.0 (excludes 1.4.0)
+#
+# SUPPORTED VERSIONS
+#   1.0.0-1.4.0  pg_tle 1.0.0 through 1.3.x (no uninstall function, no schema parameter)
+#   1.4.0-1.5.0  pg_tle 1.4.0 through 1.4.x (has uninstall function, no schema parameter)
+#   1.5.0+       pg_tle 1.5.0 and later (has uninstall function, schema parameter support)
+#
+# EXAMPLES
+#   # Generate all versions (default)
+#   pgtle.sh --extension myext
+#
+#   # Generate only for pg_tle 1.5+
+#   pgtle.sh --extension myext --pgtle-version 1.5.0+
+#
+#   # Get directory for a specific pg_tle version
+#   pgtle.sh --get-dir 1.5.2
+#   # Output: pg_tle/1.5.0+
+#
+#   pgtle.sh --get-dir 1.4.2
+#   # Output: pg_tle/1.4.0-1.5.0
+#
+#   # Get installed pg_tle version from database
+#   pgtle.sh --get-version
+#   # Output: 1.5.2 (or empty if not installed)
+#
+#   # Run generated pg_tle registration SQL files
+#   pgtle.sh --run
+#
+# OUTPUT
+#   Creates files in version-specific subdirectories:
+#     pg_tle/1.0.0-1.4.0/{extension}.sql
+#     pg_tle/1.4.0-1.5.0/{extension}.sql
+#     pg_tle/1.5.0+/{extension}.sql
+#
+#   Each file contains:
+#     - All versions of the extension
+#     - All upgrade paths between versions
+#     - Default version configuration
+#     - Complete installation instructions
+#
+#   For --get-dir: Outputs the directory path to stdout.
+#
+#   For --get-version: Outputs the installed pg_tle version to stdout, or empty if not installed.
+#
+#   For --run: Executes SQL files and outputs progress messages to stderr.
+#
+# REQUIREMENTS
+#   - Must run from extension directory (where .control files are)
+#   - Extension must use only trusted languages (PL/pgSQL, SQL, PL/Perl, etc.)
+#   - No C code (module_pathname not supported by pg_tle)
+#   - Versioned SQL files must exist: sql/{ext}--{version}.sql
+#
+# EXIT STATUS
+#   0   Success
+#   1   Error (missing files, validation failure, C code detected, etc.)
+#
+# SEE ALSO
+#   pgxntool/README-pgtle.md - Complete user guide
+#   https://github.com/aws/pg_tle - pg_tle documentation
+#
+
+set -eo pipefail
+
+# Source common library functions (error, die, debug)
+PGXNTOOL_DIR="$(dirname "${BASH_SOURCE[0]}")"
+source "$PGXNTOOL_DIR/lib.sh"
+
+# Constants
+PGTLE_DELIMITER='$_pgtle_wrap_delimiter_$'
+PGTLE_VERSIONS=("1.0.0-1.4.0" "1.4.0-1.5.0" "1.5.0+")
+
+# Supported pg_tle version ranges and their capabilities
+# Use a function instead of associative array for compatibility with bash < 4.0
+get_pgtle_capability() {
+    local version="$1"
+    case "$version" in
+        "1.0.0-1.4.0")
+            echo "no_uninstall_no_schema"
+            ;;
+        "1.4.0-1.5.0")
+            echo "has_uninstall_no_schema"
+            ;;
+        "1.5.0+")
+            echo "has_uninstall_has_schema"
+            ;;
+        *)
+            echo "unknown"
+            ;;
+    esac
+}
+
+# Global variables (populated from control file)
+EXTENSION=""
+DEFAULT_VERSION=""
+COMMENT=""
+REQUIRES=""
+SCHEMA=""
+MODULE_PATHNAME=""
+VERSION_FILES=()
+UPGRADE_FILES=()
+
+debug 1 "Global arrays initialized: VERSION_FILES=${#VERSION_FILES[@]}, UPGRADE_FILES=${#UPGRADE_FILES[@]}"
+PGTLE_VERSION=""  # Empty = generate all
+GET_DIR_VERSION=""  # For --get-dir option
+
+# Arrays (populated from SQL discovery)
+VERSION_FILES=()
+UPGRADE_FILES=()
+
+# Parse and validate a version string
+# Extracts numeric version (major.minor.patch) from version strings
+# Handles versions with suffixes like "1.5.0alpha1", "2.0beta", "1.2.3dev"
+# Returns: numeric version string (e.g., "1.5.0") or exits with error
+parse_version() {
+    local version="$1"
+
+    if [ -z "$version" ]; then
+        die 1 "Version string is empty"
+    fi
+
+    # Extract numeric version part (major.minor.patch)
+    # Matches: 1.5.0, 1.5, 10.2.1alpha, 2.0beta1, etc.
+    # Pattern: start of string, then digits, dot, digits, optionally (dot digits), then anything
+    local numeric_version
+    if [[ "$version" =~ ^([0-9]+\.[0-9]+(\.[0-9]+)?) ]]; then
+        numeric_version="${BASH_REMATCH[1]}"
+    else
+        die 1 "Cannot parse version string: '$version'
+       Expected format: major.minor[.patch][suffix]
+       Examples: 1.5.0, 1.5, 2.0alpha1, 10.2.3dev"
+    fi
+
+    # Ensure we have at least major.minor (add .0 if needed)
+    if [[ ! "$numeric_version" =~ \. ]]; then
+        die 1 "Invalid version format: '$version' (need at least major.minor)"
+    fi
+
+    # If we only have major.minor, add .0 for patch
+    if [[ ! "$numeric_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        numeric_version="${numeric_version}.0"
+    fi
+
+    echo "$numeric_version"
+}
+
+# Convert version string to comparable integer
+# Takes a numeric version string (major.minor.patch) and converts to integer
+# Example: "1.5.0" -> 1005000
+# Encoding scheme: major * 1000000 + minor * 1000 + patch
+# This limits each component to 0-999 to prevent overflow
+version_to_number() {
+    local version="$1"
+
+    # Parse major.minor.patch
+    local major minor patch
+    if [[ "$version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+        major="${BASH_REMATCH[1]}"
+        minor="${BASH_REMATCH[2]}"
+        patch="${BASH_REMATCH[3]}"
+    else
+        die 1 "version_to_number: Invalid numeric version format: '$version'"
+    fi
+
+    # Check for overflow in encoding scheme
+    # Each component must be < 1000 to fit in the allocated space
+    if [ "$major" -ge 1000 ]; then
+        die 1 "version_to_number: Major version too large: $major (max 999)
+       Version: $version"
+    fi
+    if [ "$minor" -ge 1000 ]; then
+        die 1 "version_to_number: Minor version too large: $minor (max 999)
+       Version: $version"
+    fi
+    if [ "$patch" -ge 1000 ]; then
+        die 1 "version_to_number: Patch version too large: $patch (max 999)
+       Version: $version"
+    fi
+
+    # Convert to comparable number: major * 1000000 + minor * 1000 + patch
+    echo $(( major * 1000000 + minor * 1000 + patch ))
+}
+
+# Get directory for a given pg_tle version
+# Takes a version string like "1.5.2" and returns the directory path
+# Handles versions with suffixes (e.g., "1.5.0alpha1")
+# Returns: "pg_tle/1.0.0-1.4.0", "pg_tle/1.4.0-1.5.0", or "pg_tle/1.5.0+"
+get_version_dir() {
+    local version="$1"
+
+    if [ -z "$version" ]; then
+        die 1 "Version required for --get-dir (got empty string)"
+    fi
+
+    # Parse and validate version
+    local numeric_version
+    numeric_version=$(parse_version "$version")
+
+    # Check if the original version has a pre-release suffix
+    # Pre-release versions (alpha, beta, rc, dev) are considered BEFORE the release
+    # Example: 1.4.0alpha1 comes BEFORE 1.4.0, so it should use the 1.0.0-1.4.0 range
+    local has_prerelease=0
+    if [[ "$version" =~ (alpha|beta|rc|dev) ]]; then
+        has_prerelease=1
+    fi
+
+    # Convert versions to comparable numbers
+    local version_num
+    local threshold_1_4_num
+    local threshold_1_5_num
+    version_num=$(version_to_number "$numeric_version")
+    threshold_1_4_num=$(version_to_number "1.4.0")
+    threshold_1_5_num=$(version_to_number "1.5.0")
+
+    # Compare and return appropriate directory:
+    # < 1.4.0 -> 1.0.0-1.4.0
+    # >= 1.4.0 and < 1.5.0 -> 1.4.0-1.5.0
+    # >= 1.5.0 -> 1.5.0+
+    #
+    # Special handling for pre-release versions:
+    # If version equals a threshold but has a pre-release suffix, treat it as less than that threshold
+    # Example: 1.4.0alpha1 is treated as < 1.4.0, so it uses 1.0.0-1.4.0
+    if [ "$version_num" -lt "$threshold_1_4_num" ]; then
+        echo "pg_tle/1.0.0-1.4.0"
+    elif [ "$version_num" -eq "$threshold_1_4_num" ] && [ "$has_prerelease" -eq 1 ]; then
+        # Pre-release of 1.4.0 is considered < 1.4.0
+        echo "pg_tle/1.0.0-1.4.0"
+    elif [ "$version_num" -lt "$threshold_1_5_num" ]; then
+        echo "pg_tle/1.4.0-1.5.0"
+    elif [ "$version_num" -eq "$threshold_1_5_num" ] && [ "$has_prerelease" -eq 1 ]; then
+        # Pre-release of 1.5.0 is considered < 1.5.0
+        echo "pg_tle/1.4.0-1.5.0"
+    else
+        echo "pg_tle/1.5.0+"
+    fi
+}
+
+# Get pg_tle version from installed extension
+# Returns version string or empty if not installed
+get_pgtle_version() {
+    psql --no-psqlrc --tuples-only --no-align --command "SELECT extversion FROM pg_extension WHERE extname = 'pg_tle';" 2>/dev/null | tr -d '[:space:]' || echo ""
+}
+
+# Run pg_tle registration SQL files
+# Detects installed pg_tle version and runs appropriate SQL files
+run_pgtle_sql() {
+    echo "Running pg_tle registration SQL files..." >&2
+    
+    # Get version from installed extension
+    local pgtle_version=$(get_pgtle_version)
+    if [ -z "$pgtle_version" ]; then
+        die 1 "pg_tle extension is not installed
+       Run 'CREATE EXTENSION pg_tle;' first, or use 'make check-pgtle' to verify"
+    fi
+    
+    # Get directory for this version
+    local pgtle_dir=$(get_version_dir "$pgtle_version")
+    if [ -z "$pgtle_dir" ]; then
+        die 1 "Failed to determine pg_tle directory for version $pgtle_version"
+    fi
+    
+    echo "Using pg_tle files for version $pgtle_version (directory: $pgtle_dir)" >&2
+    
+    # Check if directory exists
+    if [ ! -d "$pgtle_dir" ]; then
+        die 1 "pg_tle directory $pgtle_dir does not exist
+       Run 'make pgtle' first to generate files"
+    fi
+    
+    # Run all SQL files in the directory
+    local sql_file
+    local found=0
+    for sql_file in "$pgtle_dir"/*.sql; do
+        if [ -f "$sql_file" ]; then
+            found=1
+            echo "Running $sql_file..." >&2
+            psql --no-psqlrc -v ON_ERROR_STOP=1 --file="$sql_file" || exit 1
+        fi
+    done
+    
+    if [ "$found" -eq 0 ]; then
+        die 1 "No SQL files found in $pgtle_dir
+       Run 'make pgtle' first to generate files"
+    fi
+    
+    echo "pg_tle registration complete" >&2
+}
+
+# Main logic
+main() {
+    # Handle --get-dir, --get-version, --test-function, and --run options first (early exit, before other validation)
+    local args=("$@")
+    local i=0
+    while [ $i -lt ${#args[@]} ]; do
+        if [ "${args[$i]}" = "--get-dir" ] && [ $((i+1)) -lt ${#args[@]} ]; then
+            get_version_dir "${args[$((i+1))]}"
+            exit 0
+        elif [ "${args[$i]}" = "--get-version" ]; then
+            local version=$(get_pgtle_version)
+            if [ -n "$version" ]; then
+                echo "$version"
+                exit 0
+            else
+                exit 1
+            fi
+        elif [ "${args[$i]}" = "--test-function" ] && [ $((i+1)) -lt ${#args[@]} ]; then
+            # Hidden option for testing internal functions
+            # NOT a supported public interface - used only by the test suite
+            # Usage: pgtle.sh --test-function FUNC_NAME [ARGS...]
+            local func_name="${args[$((i+1))]}"
+            shift $((i+2))  # Remove script name and --test-function and func_name
+
+            # Check if function exists
+            if ! declare -f "$func_name" >/dev/null 2>&1; then
+                die 1 "Function '$func_name' does not exist"
+            fi
+
+            # Call the function with remaining arguments
+            "$func_name" "${args[@]:$((i+2))}"
+            exit $?
+        elif [ "${args[$i]}" = "--run" ]; then
+            run_pgtle_sql
+            exit 0
+        fi
+        i=$((i+1))
+    done
+    
+    # Parse other arguments
+    parse_args "$@"
+    
+    validate_environment
+    parse_control_file
+    discover_sql_files
+
+    if [ -z "$PGTLE_VERSION" ]; then
+        # Generate all versions
+        for version in "${PGTLE_VERSIONS[@]}"; do
+            generate_pgtle_sql "$version"
+        done
+    else
+        # Generate specific version
+        generate_pgtle_sql "$PGTLE_VERSION"
+    fi
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --extension)
+                EXTENSION="$2"
+                shift 2
+                ;;
+            --pgtle-version)
+                PGTLE_VERSION="$2"
+                shift 2
+                ;;
+            --get-dir) # This case should ideally not be hit due to early exit
+                GET_DIR_VERSION="$2"
+                shift 2
+                ;;
+            --get-version) # This case should ideally not be hit due to early exit
+                shift
+                ;;
+            --test-function) # Hidden option for testing - not documented, not supported
+                shift 2  # Skip function name and --test-function
+                ;;
+            --run) # This case should ideally not be hit due to early exit
+                shift
+                ;;
+            *)
+                echo "Unknown option: $1" >&2
+                exit 1
+                ;;
+        esac
+    done
+
+    if [ -z "$EXTENSION" ] && [ -z "$GET_DIR_VERSION" ]; then
+        die 1 "--extension is required (unless using --get-dir, --get-version, --test-function, or --run)"
+    fi
+}
+
+validate_environment() {
+    # Check if control file exists
+    if [ ! -f "${EXTENSION}.control" ]; then
+        die 1 "Control file not found: ${EXTENSION}.control
+       Must run from extension directory"
+    fi
+}
+
+parse_control_file() {
+    local control_file="${EXTENSION}.control"
+
+    echo "Parsing control file: $control_file" >&2
+
+    # Parse key = value or key = 'value' format
+    while IFS= read -r line; do
+        # Skip comments and empty lines
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+        [[ "$line" =~ ^[[:space:]]*$ ]] && continue
+
+        # Extract key = value
+        if [[ "$line" =~ ^[[:space:]]*([a-z_]+)[[:space:]]*=[[:space:]]*(.*)[[:space:]]*$ ]]; then
+            local key="${BASH_REMATCH[1]}"
+            local value="${BASH_REMATCH[2]}"
+
+            # Trim trailing comments and whitespace FIRST, then strip quotes.
+            # Order matters: stripping quotes before removing comments leaves a rogue
+            # trailing quote for values like 'version' # note. See issue #25.
+            value="${value%%#*}"  # Remove trailing comments
+            value="${value%% }"   # Trim trailing whitespace
+
+            # Strip quotes if present (both single and double)
+            value="${value#\'}"
+            value="${value%\'}"
+            value="${value#\"}"
+            value="${value%\"}"
+
+            # Store in global variables
+            case "$key" in
+                default_version) DEFAULT_VERSION="$value" ;;
+                comment) COMMENT="$value" ;;
+                requires) REQUIRES="$value" ;;
+                schema) SCHEMA="$value" ;;
+                module_pathname) MODULE_PATHNAME="$value" ;;
+            esac
+        fi
+    done < "$control_file"
+
+    # Validate required fields
+    if [ -z "$DEFAULT_VERSION" ]; then
+        die 1 "Control file missing default_version"
+    fi
+
+    if [ -z "$COMMENT" ]; then
+        echo "WARNING: Control file missing comment, using extension name" >&2
+        COMMENT="$EXTENSION extension"
+    fi
+
+    # Warn about C code
+    if [ -n "$MODULE_PATHNAME" ]; then
+        cat >&2 <<-EOF
+	WARNING: Extension uses module_pathname (C code)
+	         pg_tle only supports trusted languages (PL/pgSQL, SQL, etc.)
+	         Generated SQL will likely not work
+	EOF
+    fi
+
+    echo "  default_version: $DEFAULT_VERSION" >&2
+    echo "  comment: $COMMENT" >&2
+    if [ -n "$REQUIRES" ]; then
+        echo "  requires: $REQUIRES" >&2
+    fi
+    if [ -n "$SCHEMA" ]; then
+        echo "  schema: $SCHEMA" >&2
+    fi
+}
+
+discover_sql_files() {
+    echo "Discovering SQL files for extension: $EXTENSION" >&2
+    debug 2 "discover_sql_files: Starting discovery for extension: $EXTENSION"
+
+    # Ensure default_version file exists and has content if base file exists
+    # This handles the case where make all hasn't generated it yet, or it exists but is empty
+    local default_version_file="sql/${EXTENSION}--${DEFAULT_VERSION}.sql"
+    local base_file="sql/${EXTENSION}.sql"
+    if [ -f "$base_file" ] && ([ ! -f "$default_version_file" ] || [ ! -s "$default_version_file" ]); then
+        debug 3 "discover_sql_files: Creating default_version file from base file"
+        cp "$base_file" "$default_version_file"
+    fi
+
+    # Find versioned files: sql/{ext}--{version}.sql
+    # Use find to get proper null-delimited output, then filter out upgrade scripts
+    VERSION_FILES=()  # Reset array
+    debug 3 "discover_sql_files: Reset VERSION_FILES array"
+    while IFS= read -r -d '' file; do
+        local basename=$(basename "$file" .sql)
+        local dash_count=$(echo "$basename" | grep -o -- "--" | wc -l | tr -d '[:space:]')
+        # Skip upgrade scripts (they have 2 dashes)
+        if [ "$dash_count" -ne 1 ]; then
+            continue
+        fi
+        # Error on empty version files
+        if [ ! -s "$file" ]; then
+            die 1 "Empty version file found: $file"
+        fi
+        VERSION_FILES+=("$file")
+    done < <(find sql/ -maxdepth 1 -name "${EXTENSION}--*.sql" -print0 2>/dev/null | sort -zV)
+
+    # Find upgrade scripts: sql/{ext}--{ver1}--{ver2}.sql
+    # These have TWO occurrences of "--" in the filename
+    UPGRADE_FILES=()  # Reset array
+    debug 3 "discover_sql_files: Reset UPGRADE_FILES array"
+    while IFS= read -r -d '' file; do
+        # Empty upgrade files are allowed (no-op upgrades)
+        local basename=$(basename "$file" .sql)
+        local dash_count=$(echo "$basename" | grep -o -- "--" | wc -l | tr -d '[:space:]')
+        if [ "$dash_count" -eq 2 ]; then
+            UPGRADE_FILES+=("$file")
+        fi
+    done < <(find sql/ -maxdepth 1 -name "${EXTENSION}--*--*.sql" -print0 2>/dev/null | sort -zV)
+
+    if [ ${#VERSION_FILES[@]} -eq 0 ]; then
+        die 1 "No versioned SQL files found for $EXTENSION
+       Expected pattern: sql/${EXTENSION}--{version}.sql
+       Run 'make' first to generate versioned files from sql/${EXTENSION}.sql"
+    fi
+
+    echo "  Found ${#VERSION_FILES[@]} version file(s):" >&2
+    for f in "${VERSION_FILES[@]}"; do
+        echo "    - $f" >&2
+    done
+
+    debug 3 "discover_sql_files: Checking UPGRADE_FILES array, count=${#UPGRADE_FILES[@]}"
+    if array_not_empty "${#UPGRADE_FILES[@]}"; then
+        echo "  Found ${#UPGRADE_FILES[@]} upgrade script(s):" >&2
+        debug 2 "discover_sql_files: Iterating over ${#UPGRADE_FILES[@]} upgrade files"
+        for f in "${UPGRADE_FILES[@]}"; do
+            echo "    - $f" >&2
+        done
+    else
+        debug 2 "discover_sql_files: No upgrade files found"
+    fi
+}
+
+extract_version_from_filename() {
+    local filename="$1"
+    local basename=$(basename "$filename" .sql)
+
+    # Match patterns:
+    # - ext--1.0.0 → FROM_VERSION=1.0.0, TO_VERSION=""
+    # - ext--1.0.0--2.0.0 → FROM_VERSION=1.0.0, TO_VERSION=2.0.0
+
+    if [[ "$basename" =~ ^${EXTENSION}--([0-9][0-9.]*)(--([0-9][0-9.]*))?$ ]]; then
+        FROM_VERSION="${BASH_REMATCH[1]}"
+        TO_VERSION="${BASH_REMATCH[3]}"  # Empty for non-upgrade files
+        return 0
+    else
+        die 1 "Cannot parse version from filename: $filename
+       Expected format: ${EXTENSION}--{version}.sql or ${EXTENSION}--{ver1}--{ver2}.sql"
+    fi
+}
+
+validate_delimiter() {
+    local sql_file="$1"
+
+    if grep -qF "$PGTLE_DELIMITER" "$sql_file"; then
+        die 1 "SQL file contains reserved pg_tle delimiter: $sql_file
+       Found: $PGTLE_DELIMITER
+       This delimiter is used internally by pgtle.sh to wrap SQL content.
+       You must modify your SQL to not contain this string. If this poses a
+       serious problem, please open an issue at https://github.com/decibel/pgxntool/issues"
+    fi
+}
+
+wrap_sql_content() {
+    local sql_file="$1"
+
+    validate_delimiter "$sql_file"
+
+    # Output wrapped SQL with proper indentation
+    # Empty files are valid (no-op upgrades)
+    echo "  ${PGTLE_DELIMITER}"
+    cat "$sql_file"
+    echo "  ${PGTLE_DELIMITER}"
+}
+
+build_requires_array() {
+    # Input: "plpgsql, other_ext, another"
+    # Output: 'plpgsql', 'other_ext', 'another'
+
+    # Split on comma, trim whitespace, quote each element
+    REQUIRES_ARRAY=$(echo "$REQUIRES" | \
+        sed 's/[[:space:]]*,[[:space:]]*/\n/g' | \
+        sed "s/^[[:space:]]*//;s/[[:space:]]*$//" | \
+        sed "s/^/'/;s/$/'/" | \
+        paste -sd, -)
+}
+
+generate_header() {
+    local pgtle_version="$1"
+    local output_file="$2"
+    local version_count=${#VERSION_FILES[@]}
+    local upgrade_count=${#UPGRADE_FILES[@]}
+
+    # Determine version compatibility message
+    local compat_msg
+    if [[ "$pgtle_version" == *"+"* ]]; then
+        local base_version="${pgtle_version%+}"
+        compat_msg="--     Works on pg_tle >= ${base_version}"
+    else
+        local min_version="${pgtle_version%-*}"
+        local max_version="${pgtle_version#*-}"
+        compat_msg="--     Works on pg_tle >= ${min_version} and < ${max_version}"
+    fi
+
+    cat <<EOF
+/*
+ * Generated by pgxntool/pgtle.sh
+ * Extension: ${EXTENSION}
+ * Target pg_tle version: ${pgtle_version}
+ * Generated: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+ *
+ * This file contains complete pg_tle registration for ${EXTENSION}:
+ *   - All versions: ${version_count} version(s)
+ *   - Upgrade paths: ${upgrade_count} path(s)
+ *   - Default version: ${DEFAULT_VERSION}
+ *
+ * Installation:
+ *   Recommended: make run-pgtle
+ *   (or: pgxntool/pgtle.sh --run)
+ *
+ *   This automatically detects your pg_tle version and runs the correct file.
+ *
+ *   Prerequisites:
+ *   - pg_tle extension installed (CREATE EXTENSION pg_tle;)
+ *   - pgtle_admin role (GRANT pgtle_admin TO your_username;)
+ *
+ *   After registration, create the extension:
+ *      CREATE EXTENSION ${EXTENSION};
+ *
+ * Version compatibility:
+ *   ${pgtle_version} means:
+ *      ${compat_msg#--     }
+ */
+
+EOF
+}
+
+generate_install_extension() {
+    local sql_file="$1"
+    local capability="$2"
+
+    # Extract version from filename (must be versioned file: sql/{ext}--{version}.sql)
+    extract_version_from_filename "$sql_file"
+    local version="$FROM_VERSION"
+
+    echo "-- Install version $version"
+    echo "SELECT pgtle.install_extension("
+    echo "  '${EXTENSION}',"
+    echo "  '${version}',"
+    echo "  '${COMMENT}',"
+    wrap_sql_content "$sql_file"
+
+    # Build requires array
+    if [ -n "$REQUIRES" ]; then
+        build_requires_array
+        echo "  , ARRAY[${REQUIRES_ARRAY}]"
+    else
+        echo "  , NULL"
+    fi
+
+    # Add schema parameter only for capability version 1.5.0+
+    if [ "$capability" = "has_uninstall_has_schema" ]; then
+        if [ -n "$SCHEMA" ]; then
+            echo "  , '${SCHEMA}'  -- schema parameter (pg_tle 1.5.0+)"
+        else
+            echo "  , NULL  -- schema parameter (pg_tle 1.5.0+)"
+        fi
+    fi
+
+    echo ");"
+    echo
+}
+
+generate_install_extension_version_sql() {
+    local sql_file="$1"
+
+    extract_version_from_filename "$sql_file"
+    local version="$FROM_VERSION"
+
+    echo "-- Install version $version"
+    echo "SELECT pgtle.install_extension_version_sql("
+    echo "  '${EXTENSION}',"
+    echo "  '${version}',"
+    wrap_sql_content "$sql_file"
+    echo ");"
+    echo
+}
+
+generate_install_update_path() {
+    local upgrade_file="$1"
+
+    extract_version_from_filename "$upgrade_file"
+    local from_ver="$FROM_VERSION"
+    local to_ver="$TO_VERSION"
+
+    echo "-- Upgrade path: $from_ver -> $to_ver"
+    echo "SELECT pgtle.install_update_path("
+    echo "  '${EXTENSION}',"
+    echo "  '${from_ver}',"
+    echo "  '${to_ver}',"
+    wrap_sql_content "$upgrade_file"
+    echo ");"
+    echo
+}
+
+generate_pgtle_sql() {
+    local pgtle_version="$1"
+    debug 2 "generate_pgtle_sql: Starting for version $pgtle_version, extension $EXTENSION"
+    
+    # Get capability using function (compatible with bash < 4.0)
+    local capability=$(get_pgtle_capability "$pgtle_version")
+    local version_dir="pg_tle/${pgtle_version}"
+    local output_file="${version_dir}/${EXTENSION}.sql"
+    
+    # Ensure arrays are initialized (defensive programming)
+    # Arrays should already be initialized at top level, but ensure they exist
+    debug 3 "generate_pgtle_sql: Checking array initialization"
+    debug 2 "generate_pgtle_sql: VERSION_FILES is ${VERSION_FILES+set}, count=${#VERSION_FILES[@]}"
+    debug 2 "generate_pgtle_sql: UPGRADE_FILES is ${UPGRADE_FILES+set}, count=${#UPGRADE_FILES[@]}"
+    
+    if [ -z "${VERSION_FILES+set}" ]; then
+        echo "WARNING: VERSION_FILES not set, initializing" >&2
+        VERSION_FILES=()
+    fi
+    if [ -z "${UPGRADE_FILES+set}" ]; then
+        echo "WARNING: UPGRADE_FILES not set, initializing" >&2
+        UPGRADE_FILES=()
+    fi
+
+    # Create version-specific output directory if needed
+    mkdir -p "$version_dir"
+
+    echo "Generating: $output_file (pg_tle $pgtle_version)" >&2
+
+    # Generate SQL to file
+    {
+        generate_header "$pgtle_version" "$output_file"
+
+        cat <<EOF
+BEGIN;
+
+EOF
+
+        # Only include uninstall block for pg_tle 1.4.0+ (versions with uninstall support)
+        if [ "$capability" != "no_uninstall_no_schema" ]; then
+            cat <<EOF
+/*
+ * Uninstall extension if it exists (idempotent registration)
+ * Silently ignore if extension not found
+ */
+DO \$\$
+BEGIN
+    PERFORM pgtle.uninstall_extension('${EXTENSION}');
+EXCEPTION
+    WHEN no_data_found THEN
+        -- Extension not registered yet (pg_tle raises P0002, not 42704)
+        NULL;
+END
+\$\$;
+
+EOF
+        fi
+
+        # Install base version (first version file)
+        if array_not_empty "${#VERSION_FILES[@]}"; then
+            generate_install_extension "${VERSION_FILES[0]}" "$capability"
+        fi
+
+        # Install additional versions (remaining version files)
+        if [ ${#VERSION_FILES[@]} -gt 1 ]; then
+            for version_file in "${VERSION_FILES[@]:1}"; do
+                generate_install_extension_version_sql "$version_file"
+            done
+        fi
+
+        # Install all upgrade paths
+        local upgrade_count=${#UPGRADE_FILES[@]}
+        debug 3 "generate_pgtle_sql: upgrade_count=$upgrade_count"
+        if [ "$upgrade_count" -gt 0 ]; then
+            debug 2 "generate_pgtle_sql: Processing $upgrade_count upgrade path(s)"
+            local i=0
+            while [ "$i" -lt "$upgrade_count" ]; do
+                debug 4 "generate_pgtle_sql: Processing upgrade file $i: ${UPGRADE_FILES[$i]}"
+                generate_install_update_path "${UPGRADE_FILES[$i]}"
+                i=$((i + 1))
+            done
+        else
+            debug 2 "generate_pgtle_sql: No upgrade paths to process"
+        fi
+
+        cat <<EOF
+-- Set default version
+SELECT pgtle.set_default_version('${EXTENSION}', '${DEFAULT_VERSION}');
+
+COMMIT;
+EOF
+    } > "$output_file"
+
+    echo "  ✓ Generated: $output_file" >&2
+}
+
+main "$@"
+

--- a/pgtle_versions.md
+++ b/pgtle_versions.md
@@ -1,0 +1,47 @@
+# pg_tle Version Support Matrix
+
+This file documents pg_tle version boundaries that affect pgxntool's pg_tle support code. Each boundary represents a backward-incompatible API change.
+
+## Version Ranges (pgxntool notation)
+
+### 1.0.0-1.4.0
+- **pg_tle versions:** 1.0.0 through 1.3.x
+- **PostgreSQL support:** 11-17
+- **API:** No `pgtle.uninstall_extension()` function, no schema parameter
+- **Features:** Basic extension management, custom data types, authentication hooks
+
+### 1.4.0-1.5.0
+- **pg_tle versions:** 1.4.0 through 1.4.x
+- **PostgreSQL support:** 11-17
+- **API:** Added `pgtle.uninstall_extension()` function, no schema parameter
+- **Features:** Custom alignment/storage, enhanced warnings
+
+### 1.5.0+
+- **pg_tle versions:** 1.5.0 and later (tested through 1.5.2)
+- **PostgreSQL support:** 12-18 (dropped PG 11)
+- **API:** BREAKING CHANGE - `pgtle.install_extension()` now requires schema parameter
+- **Features:** Schema parameter support in installation
+
+## Key API Changes by Version
+
+**1.4.0:** Added `pgtle.uninstall_extension()`
+- Versions before 1.4.0 cannot uninstall extensions
+
+**1.5.0:** Changed `pgtle.install_extension()` signature
+- Added required `schema` parameter
+- Dropped PostgreSQL 11 support
+
+## Version Notation
+
+- `X.Y.Z+` - Works on pg_tle >= X.Y.Z
+- `X.Y.Z-A.B.C` - Works on pg_tle >= X.Y.Z and < A.B.C
+
+**Boundary conditions:**
+- `1.5.0+` means >= 1.5.0 (includes 1.5.0)
+- `1.4.0-1.5.0` means >= 1.4.0 and < 1.5.0 (excludes 1.5.0)
+- `1.0.0-1.4.0` means >= 1.0.0 and < 1.4.0 (excludes 1.4.0)
+
+## For Complete Details
+
+- `pgtle.sh` (comments at top)
+- https://github.com/aws/pg_tle

--- a/run-test-build.sh
+++ b/run-test-build.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# pgxntool/run-test-build.sh - Prepare test/build/ for the test-build target
+#
+# Sets up the generated sql/ directory and ensures expected/*.out files exist
+# so pg_regress can run without aborting on missing files.
+#
+# Usage: run-test-build.sh TESTDIR
+#
+# Called by the test-build target in base.mk before running installcheck.
+
+set -e
+
+TESTDIR="${1:?Usage: run-test-build.sh TESTDIR}"
+BUILD_DIR="$TESTDIR/build"
+SQL_DIR="$BUILD_DIR/sql"
+EXPECTED_DIR="$BUILD_DIR/expected"
+
+mkdir -p "$SQL_DIR"
+mkdir -p "$EXPECTED_DIR"
+
+# Verify .sql files exist. This script is only called when test-build is
+# enabled, so missing files indicate a misconfiguration.
+files=("$BUILD_DIR"/*.sql)
+if [ ! -f "${files[0]}" ]; then
+	echo "ERROR: no .sql files found in $BUILD_DIR/" >&2
+	exit 1
+fi
+
+# Sync .sql files to sql/ directory for pg_regress.
+# --checksum: compare by content, not size+mtime. rsync's default "quick check"
+#   assumes equal size+mtime means files are identical, which isn't safe here —
+#   builds can produce identical-sized files with different content. Checksum
+#   comparison also avoids unnecessary writes that could trigger antivirus.
+# --times: preserve source mtimes on destination files so make's dependency
+#   tracking works correctly.
+# --delete: remove files from sql/ that no longer exist in build/.
+# --include/--exclude: select only *.sql from the directory source
+#   (--delete requires a directory transfer, not individual file arguments).
+rsync -r --checksum --times --delete --include='*.sql' --exclude='*' "$BUILD_DIR/" "$SQL_DIR/"
+
+# Create empty expected/*.out files for .sql tests (if not already present).
+# pg_regress requires an expected file to exist for each test; without it
+# pg_regress stops immediately rather than running the test and showing the diff.
+for file in "$BUILD_DIR"/*.sql; do
+	out="$EXPECTED_DIR/$(basename "$file" .sql).out"
+	[ -f "$out" ] || touch "$out"
+done

--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,10 @@
 set -o errexit -o errtrace -o pipefail
 trap 'echo "Error on line ${LINENO}"' ERR
 
+# Source common library functions (error, die, debug)
+PGXNTOOL_DIR="$(dirname "${BASH_SOURCE[0]}")"
+source "$PGXNTOOL_DIR/lib.sh"
+
 [ -d .git ] || git init
 
 if ! git diff --cached --exit-code; then
@@ -35,21 +39,44 @@ safecp () {
     fi
 }
 
-safecp pgxntool/_.gitignore .gitignore
-safecp pgxntool/META.in.json META.in.json
+# =============================================================================
+# SETUP FILES
+# =============================================================================
+# SETUP_FILES and SETUP_SYMLINKS are defined in lib.sh
+# These are also used by update-setup-files.sh for sync updates.
+# =============================================================================
 
+# Copy tracked setup files (defined in lib.sh)
+for entry in "${SETUP_FILES[@]}"; do
+    src="pgxntool/${entry%%:*}"
+    dest="${entry##*:}"
+    # Create parent directory if needed
+    mkdir -p "$(dirname "$dest")"
+    safecp "$src" "$dest"
+done
+
+# Create tracked symlinks (defined in lib.sh)
+for entry in "${SETUP_SYMLINKS[@]}"; do
+    dest="${entry%%:*}"
+    target="${entry##*:}"
+    mkdir -p "$(dirname "$dest")"
+    if [ ! -e "$dest" ]; then
+        echo "Creating symlink $dest -> $target"
+        ln -s "$target" "$dest"
+        git add "$dest"
+    else
+        echo "$dest already exists"
+    fi
+done
+
+# META.in.json and Makefile are NOT in SETUP_FILES because users heavily customize them
+safecp pgxntool/META.in.json META.in.json
 safecreate Makefile include pgxntool/base.mk
 
 make META.json
 git add META.json
 
-mkdir -p sql test src
-
-cd test
-mkdir -p sql
-safecp ../pgxntool/test/deps.sql deps.sql
-[ -d pgxntool ] || ln -s ../pgxntool/test/pgxntool .
-git add pgxntool
+mkdir -p sql test/sql src
 git status
 
 echo "If you won't be creating C code then you can:

--- a/update-setup-files.sh
+++ b/update-setup-files.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+#
+# update-setup-files.sh - Update files that were initially copied by setup.sh
+#
+# This script handles the 3-way merge of setup files after a pgxntool subtree
+# update. It compares the old pgxntool version, new pgxntool version, and
+# user's current file to determine the appropriate action:
+#
+#   1. If pgxntool didn't change the file: skip (nothing to do)
+#   2. If user hasn't modified the file: auto-update
+#   3. If both changed: 3-way merge with conflict markers
+#
+# Usage: update-setup-files.sh <old-pgxntool-commit>
+#
+# The old commit is the pgxntool subtree commit BEFORE the sync.
+
+set -o errexit -o errtrace -o pipefail
+trap 'echo "Error on line ${LINENO}"' ERR
+
+PGXNTOOL_DIR="$(dirname "${BASH_SOURCE[0]}")"
+source "$PGXNTOOL_DIR/lib.sh"
+
+# SETUP_FILES and SETUP_SYMLINKS are defined in lib.sh
+
+# =============================================================================
+# Functions
+# =============================================================================
+
+usage() {
+    echo "Usage: $0 <old-pgxntool-commit>"
+    echo
+    echo "Updates setup files after a pgxntool subtree sync."
+    echo
+    echo "Arguments:"
+    echo "  old-pgxntool-commit  The pgxntool commit hash BEFORE the sync"
+    exit 1
+}
+
+# Get file content from a specific commit
+# Usage: get_old_content <commit> <path-in-pgxntool>
+get_old_content() {
+    local commit=$1
+    local path=$2
+    git show "${commit}:pgxntool/${path}" 2>/dev/null
+}
+
+# Get current file content from pgxntool directory
+# Usage: get_new_content <path-in-pgxntool>
+get_new_content() {
+    local path=$1
+    cat "pgxntool/${path}" 2>/dev/null
+}
+
+# Process a single setup file
+# Usage: process_file <source> <dest> <old_commit>
+process_file() {
+    local source=$1
+    local dest=$2
+    local old_commit=$3
+
+    # Get the three versions
+    local old_content new_content user_content
+
+    old_content=$(get_old_content "$old_commit" "$source") || {
+        debug 20 "Could not get old version of $source (new file in pgxntool?)"
+        old_content=""
+    }
+
+    new_content=$(get_new_content "$source") || {
+        error "Could not read pgxntool/$source"
+        return 1
+    }
+
+    # Check if destination exists
+    if [[ ! -e "$dest" ]]; then
+        echo "  $dest: creating (file was missing)"
+        cp "pgxntool/$source" "$dest"
+        return 0
+    fi
+
+    user_content=$(cat "$dest")
+
+    # Step 1: Did pgxntool change this file?
+    if [[ "$old_content" == "$new_content" ]]; then
+        debug 30 "$dest: pgxntool unchanged, skipping"
+        return 0
+    fi
+
+    # Step 2: Did user modify their copy?
+    if [[ "$user_content" == "$old_content" ]]; then
+        echo "  $dest: updated (you hadn't modified it)"
+        cp "pgxntool/$source" "$dest"
+        return 0
+    fi
+
+    # Step 3: Both changed - need 3-way merge
+    echo "  $dest: attempting 3-way merge..."
+
+    # Create temp files for git merge-file
+    local tmp_old tmp_new
+    tmp_old=$(mktemp)
+    tmp_new=$(mktemp)
+    trap "rm -f '$tmp_old' '$tmp_new'" RETURN
+
+    echo "$old_content" > "$tmp_old"
+    echo "$new_content" > "$tmp_new"
+
+    # git merge-file modifies the first file in place
+    # Returns 0 on clean merge, >0 if conflicts (but still writes result)
+    if git merge-file -L "yours" -L "old pgxntool" -L "new pgxntool" \
+        "$dest" "$tmp_old" "$tmp_new"; then
+        echo "  $dest: merged cleanly (please review)"
+    else
+        echo "  $dest: CONFLICTS - resolve manually"
+    fi
+}
+
+# Process a symlink
+# Usage: process_symlink <dest> <target>
+process_symlink() {
+    local dest=$1
+    local target=$2
+
+    if [[ -L "$dest" ]]; then
+        local current_target
+        current_target=$(readlink "$dest")
+        if [[ "$current_target" == "$target" ]]; then
+            debug 30 "$dest: symlink unchanged"
+        else
+            echo "  $dest: symlink points to '$current_target', expected '$target'"
+            echo "         (not auto-fixing - please check manually)"
+        fi
+    elif [[ -e "$dest" ]]; then
+        echo "  $dest: exists but is not a symlink (expected symlink to $target)"
+    else
+        echo "  $dest: creating symlink to $target"
+        ln -s "$target" "$dest"
+    fi
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+[[ $# -eq 1 ]] || usage
+
+old_commit=$1
+
+# Verify we're in a git repo with pgxntool subtree
+[[ -d "pgxntool" ]] || die 1 "pgxntool directory not found. Run from project root."
+[[ -d ".git" ]] || die 1 "Not in a git repository."
+
+# Verify the old commit is valid
+if ! git cat-file -e "${old_commit}^{commit}" 2>/dev/null; then
+    die 1 "Invalid commit: $old_commit"
+fi
+
+echo "Checking setup files for updates..."
+echo
+
+# Process regular files
+for entry in "${SETUP_FILES[@]}"; do
+    source="${entry%%:*}"
+    dest="${entry##*:}"
+    process_file "$source" "$dest" "$old_commit"
+done
+
+# Process symlinks
+for entry in "${SETUP_SYMLINKS[@]}"; do
+    dest="${entry%%:*}"
+    target="${entry##*:}"
+    process_symlink "$dest" "$target"
+done
+
+echo
+echo "Done. Review changes with 'git diff' and commit when ready."

--- a/verify-results-pgtap.sh
+++ b/verify-results-pgtap.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# pgxntool/verify-results-pgtap.sh - Check pgtap results before 'make results'
+#
+# Scans pgtap output files for failures and plan mismatches, then checks
+# regression.diffs as a fallback. Exits non-zero if any problems are found.
+#
+# Usage: verify-results-pgtap.sh TESTOUT
+#
+# Called by the verify-results target in base.mk (pgtap mode).
+
+set -e
+
+TESTOUT="${1:?Usage: verify-results-pgtap.sh TESTOUT}"
+
+# Check for pgtap failures in result files (excluding TODO items)
+failed=0
+for f in "$TESTOUT"/results/*.out; do
+	[ -f "$f" ] || continue
+	if grep -q '^not ok' "$f"; then
+		notok=$(grep '^not ok' "$f" | grep -v '# TODO' || true)
+		if [ -n "$notok" ]; then
+			echo "ERROR: pgtap failure detected in $f"
+			echo "$notok"
+			failed=1
+		fi
+	fi
+	if grep -q 'Looks like you planned' "$f"; then
+		echo "ERROR: pgtap plan mismatch in $f"
+		grep 'Looks like you planned' "$f"
+		failed=1
+	fi
+done
+if [ $failed -ne 0 ]; then
+	echo
+	echo "pgtap failures detected. Cannot run 'make results'."
+	exit 1
+fi
+
+# Also check regression.diffs (output mismatch even if pgtap all passed)
+if [ -r "$TESTOUT/regression.diffs" ]; then
+	echo "ERROR: Tests are failing. Cannot run 'make results'."
+	echo "Fix test failures first, then run 'make results'."
+	echo
+	echo "See $TESTOUT/regression.diffs for details:"
+	cat "$TESTOUT/regression.diffs"
+	exit 1
+fi


### PR DESCRIPTION
## Summary

- Updates pgxntool subtree from the previous stable release to 2.0.2

## Test plan
- [ ] Verify `make` and `make installcheck` still work after pgxntool update

🤖 Generated with [Claude Code](https://claude.com/claude-code)