### PR TITLE
README: remove redundant cat_tools. schema prefix

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -17,41 +17,41 @@ Works on Postgres 9.3 and above.
 
 == Data Types
 
-* `cat_tools.object_type` - Descriptive names for every type of Postgres object (table, operator, rule, etc)
-* `cat_tools.constraint_type` - Types of constraints (`domain constraint` or `table_constraint`)
-* `cat_tools.relation_type` - Types of objects stored in `pg_class`
-* `cat_tools.relation_relkind` - Valid values for `pg_class.relkind`
+* `object_type` - Descriptive names for every type of Postgres object (table, operator, rule, etc)
+* `constraint_type` - Types of constraints (`domain constraint` or `table_constraint`)
+* `relation_type` - Types of objects stored in `pg_class`
+* `relation_relkind` - Valid values for `pg_class.relkind`
 
 == Functions
 
-* `cat_tools.currval(table, column)` - Returns current value for a sequence owned by a column
-* `cat_tools.enum_range(regtype)` - Returns valid values for an ENUM as an array
-* `cat_tools.enum_range_srf(regtype)` - Returns valid values for an ENUM as a recordset
-* `cat_tools.name__check(text)` - Throws an error if input would be truncated when cast to name
-* `cat_tools.pg_class(relation regclass)` - Returns cat_tools.pg_class_v row for a relation
-* `cat_tools.pg_extension__get(extension_name name)` - Returns cat_tools.pg_extension_v row for an extension
-* `cat_tools.extension__schemas(extension_names text/name[])` - Returns the schemas for the requested functions
-* `cat_tools.extension__schemas_unique(extension_names text/name[])` - Returns a unique array of schemas
-* `cat_tools.function__arg_types(arguments)` - Accepts full function argument string and returns regtype[] of IN/INOUT arguments
-* `cat_tools.function__arg_types_text(arguments)` - Version of `function__arg_types` that returns text
-* `cat_tools.object__catalog(object_type)` - Returns catalog table that is used to store `object_type` objects
-* `cat_tools.object__reg_type(object_catalog)` - Returns the "reg" pseudotype (ie: regclass) associated with a system catalog (ie: pg_class)
-* `cat_tools.regprocedure(function_name, arguments)` - Returns regprocedure for function_name and it's full set of arguments
-* `cat_tools.relation__kind(relkind)` - Mapping from `pg_class.relkind` to a `cat_tools.relation_type`
-* `cat_tools.relation__relkind(relation_type)` - Mapping from `cat_tools.relation_type` to a `pg_class.relkind` value
-* `cat_tools.trigger__args_as_text(text)` - Converts the arguments for a trigger function (as returned by `trigger__parse()`) to text (for backwards compatibility).
-* `cat_tools.trigger__get_oid(trigger_table, trigger_name)` - oid of a trigger. Throws error if trigger doesn't exits.
-* `cat_tools.trigger__get_oid__loose(trigger_table, trigger_name)` - oid of a trigger. Does _not_ throw error if trigger doesn't exits.
-* `cat_tools.trigger__parse(trigger oid)` - Returns information about a trigger
-* `cat_tools.trigger__parse(table_name regclass, trigger_name text)` - Returns information about a trigger
+* `currval(table, column)` - Returns current value for a sequence owned by a column
+* `enum_range(regtype)` - Returns valid values for an ENUM as an array
+* `enum_range_srf(regtype)` - Returns valid values for an ENUM as a recordset
+* `name__check(text)` - Throws an error if input would be truncated when cast to name
+* `pg_class(relation regclass)` - Returns pg_class_v row for a relation
+* `pg_extension__get(extension_name name)` - Returns pg_extension_v row for an extension
+* `extension__schemas(extension_names text/name[])` - Returns the schemas for the requested functions
+* `extension__schemas_unique(extension_names text/name[])` - Returns a unique array of schemas
+* `function__arg_types(arguments)` - Accepts full function argument string and returns regtype[] of IN/INOUT arguments
+* `function__arg_types_text(arguments)` - Version of `function__arg_types` that returns text
+* `object__catalog(object_type)` - Returns catalog table that is used to store `object_type` objects
+* `object__reg_type(object_catalog)` - Returns the "reg" pseudotype (ie: regclass) associated with a system catalog (ie: pg_class)
+* `regprocedure(function_name, arguments)` - Returns regprocedure for function_name and it's full set of arguments
+* `relation__kind(relkind)` - Mapping from `pg_class.relkind` to a `relation_type`
+* `relation__relkind(relation_type)` - Mapping from `relation_type` to a `pg_class.relkind` value
+* `trigger__args_as_text(text)` - Converts the arguments for a trigger function (as returned by `trigger__parse()`) to text (for backwards compatibility).
+* `trigger__get_oid(trigger_table, trigger_name)` - oid of a trigger. Throws error if trigger doesn't exits.
+* `trigger__get_oid__loose(trigger_table, trigger_name)` - oid of a trigger. Does _not_ throw error if trigger doesn't exits.
+* `trigger__parse(trigger oid)` - Returns information about a trigger
+* `trigger__parse(table_name regclass, trigger_name text)` - Returns information about a trigger
 
 == Views
 WARNING: These views may eventually move into a separate extension!
 
-* `cat_tools.pg_class_v` - Joins pg_class to pg_namespace
-* `cat_tools.pg_extension_v` - Joins pg_extension to pg_namespace; cast extconfig to regclass[]
-* `cat_tools.column` - Returns data about columns
-* `cat_tools.pg_all_foreign_keys` - Data about foreign keys
+* `pg_class_v` - Joins pg_class to pg_namespace
+* `pg_extension_v` - Joins pg_extension to pg_namespace; cast extconfig to regclass[]
+* `column` - Returns data about columns
+* `pg_all_foreign_keys` - Data about foreign keys
 
 Copyright and License
 ---------------------


### PR DESCRIPTION
Since all documented objects live in the `cat_tools` schema, repeating the schema name on every line is noise. Remove it throughout.