### PR TITLE
ci: update actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Start PostgreSQL ${{ matrix.pg }}
         run: pg-start ${{ matrix.pg }}
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install rsync
         run: apt-get install -y rsync
       - name: Test on PostgreSQL ${{ matrix.pg }}
@@ -67,7 +67,7 @@ jobs:
           pg_ctlcluster ${{ matrix.old_pg }} test start
           pg_isready -t 30
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install rsync
         run: apt-get install -y rsync
       - name: Install cat_tools into old cluster
@@ -133,7 +133,7 @@ jobs:
       - name: Start PostgreSQL ${{ matrix.pg }}
         run: pg-start ${{ matrix.pg }}
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install rsync
         run: apt-get install -y rsync
       - name: Install cat_tools (all versions)
@@ -167,7 +167,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Verify all jobs are listed in needs
         # Ensures this job won't silently ignore a newly-added job that was
         # omitted from the needs list above.


### PR DESCRIPTION
`actions/checkout@v4` uses Node.js 20, which is deprecated on GitHub Actions
runners and will be forced to Node.js 24 starting June 2, 2026. Update to v6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)